### PR TITLE
Add Ecuador arterial, collector shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -116,6 +116,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 
 .ca,
 .us,
+.ec,
 .bd,
 .cn,
 .hk,

--- a/icons/shield40_ec_collector_3.svg
+++ b/icons/shield40_ec_collector_3.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="25"
+   height="20"
+   version="1.0"
+   viewBox="0 0 24.966 19.967"
+   id="svg17"
+   sodipodi:docname="shield40_ec_collector_3.svg"
+   inkscape:version="1.2 (dc2aeda, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs21" />
+  <sodipodi:namedview
+     id="namedview19"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.8"
+     inkscape:cx="12.542373"
+     inkscape:cy="10.042373"
+     inkscape:window-width="1440"
+     inkscape:window-height="855"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg17" />
+  <path
+     style="fill:#bf2033;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 0.49931998,4.499264 C 0.66013121,3.2329581 1.1086041,1.7689041 1.5831516,0.63365107 h 2.661e-4 C 3.2767759,1.093957 5.0568447,1.33942 6.8932125,1.33942 c 1.9385508,0 3.8141485,-0.273486 5.5912885,-0.78449493 1.777174,0.51101193 3.652772,0.78449493 5.59129,0.78449493 1.8365,0 3.616502,-0.245446 5.309794,-0.70576893 C 23.860133,1.768803 24.305902,3.232823 24.46668,4.499264 Z"
+     id="path9" />
+  <path
+     style="fill:#006747;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 24.46668,4.4992637 c 0.03805,0.41447 -0.01248,0.992128 -0.01248,1.416525 h 3e-6 c 0,6.9563073 -5.225427,12.6940743 -11.971197,13.5128543 C 5.7372308,18.609796 0.51180302,12.872096 0.51180302,5.9157887 h 4.988e-5 c 0,-0.424397 -0.0505759,-1.002055 -0.0125329,-1.416525 z"
+     id="path11" />
+  <path
+     style="fill:none;stroke:#fff;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 24.454197,5.915789 c 0,6.956307 -5.225427,12.694074 -11.971197,13.512854 C 5.7372308,18.609796 0.51180302,12.872096 0.51180302,5.915789 h 4.988e-5 c 0,-0.4243975 0.0194519,-0.8442461 0.0574949,-1.2587162 C 0.73015903,3.3907669 1.1086041,1.7689039 1.5831516,0.63365107 h 2.661e-4 C 3.2767759,1.0939572 5.0568447,1.33942 6.8932125,1.33942 c 1.9385508,0 3.8141485,-0.2734863 5.5912885,-0.78449529 1.777174,0.51101239 3.652772,0.78449529 5.59129,0.78449529 1.8365,0 3.616502,-0.245446 5.309794,-0.70576893 0.474548,1.13515163 0.850324,2.75698093 1.011102,4.02342173 0.03805,0.4144701 0.05751,0.8343187 0.05751,1.2587162 z"
+     id="path13" />
+  <path
+     style="fill:none;stroke:#fff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 0.49931998,4.4992637 H 24.46668"
+     id="path15" />
+</svg>

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2402,10 +2402,8 @@ export function loadShields(shieldImages) {
   // Ecuador
   shields["EC:national"] = shields["US:I"];
   shields["EC:provincial"] = {
+    ...shields["US:I"],
     backgroundImage: shieldImages.shield40_ec_collector_3,
-    textLayoutConstraint: ShieldText.southHalfellipseTextConstraint,
-    textColor: Color.shields.white,
-    padding: padding_us_interstate,
   };
 
   // ASIA

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2397,6 +2397,17 @@ export function loadShields(shieldImages) {
     (county) => (shields[`US:WY:${county}`] = pentagonShieldBlueYellow)
   );
 
+  // SOUTH AMERICA
+
+  // Ecuador
+  shields["EC:national"] = shields["US:I"];
+  shields["EC:provincial"] = {
+    backgroundImage: shieldImages.shield40_ec_collector_3,
+    textLayoutConstraint: ShieldText.southHalfellipseTextConstraint,
+    textColor: Color.shields.white,
+    padding: padding_us_interstate,
+  };
+
   // ASIA
 
   // Bangladesh


### PR DESCRIPTION
Added shield definitions for the arterial and collector routes in Ecuador’s national highway network.

[<img src="https://user-images.githubusercontent.com/1231218/175799671-202e2f5e-e244-4e17-b0b3-79e089d88f74.png" width="400" alt="Ambato">](https://americanamap.org/#12/-1.28451/-78.61955)

The “E” is intentional; that’s how the signs look in the real world and apparently on maps.

Fixes #455.