### PR TITLE
Cyprus motorway shields

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -4102,6 +4102,13 @@ export function loadShields() {
   );
 
   // Cyprus
+  shields["CY:motorway"] = hexagonVerticalShield(
+    2,
+    Color.shields.green,
+    Color.shields.yellow,
+    Color.shields.yellow,
+    0
+  );
   shields["CY:B"] =
     shields["CY:E"] =
     shields["CY:F"] =


### PR DESCRIPTION
Added a shield definition for A roads (motorways) in Cyprus, as well as Akrotiri and Dhekelia, a British Overseas Territory. So far only A roads have been mapped; B roads (main roads) and E roads (secondary roads) don’t have relations yet.

[<img src="https://user-images.githubusercontent.com/1231218/194747166-f7b2518b-4407-4441-a1e3-68c71b2b8ea6.png" width="600" alt="larnaca">](https://americanamap.org/#11/34.9456/33.6107)

[<img src="https://user-images.githubusercontent.com/1231218/194747238-e0b9c8d0-8e10-419b-b562-4b3f029ced62.png" width="600" alt="dhekalia">](https://americanamap.org/#13/35.00977/33.71338)