### PR TITLE
Make pentagon shields symmetrical

### DIFF
--- a/src/js/shield_canvas_draw.js
+++ b/src/js/shield_canvas_draw.js
@@ -440,10 +440,10 @@ export function pentagon(
   let halfComplementAngle2 = (Math.PI / 2 - angle) / 2;
   let halfComplementTangent2 = Math.tan(halfComplementAngle2);
 
-  let x1 = x0 + angleSign * drawRadius1 * halfComplementTangent1 * sine;
+  let x1 = x0 + drawRadius1 * halfComplementTangent1 * sine;
   let x3 = x2 + drawRadius2 * halfComplementTangent2;
   let x5 = x6 - drawRadius2 * halfComplementTangent2;
-  let x7 = x8 - angleSign * drawRadius1 * halfComplementTangent1 * sine;
+  let x7 = x8 - drawRadius1 * halfComplementTangent1 * sine;
   let y1 = y2 - angleSign * drawRadius1 * halfComplementTangent1 * cosine;
 
   ctx.beginPath();


### PR DESCRIPTION
I made a mistake in calculating some control points and it ended up in ever-so-slightly lopsided pentagons. This should make them truly symmetrical.

before, after, diff:
![old-5](https://user-images.githubusercontent.com/1732117/212223526-1966505a-ec91-419a-b5c1-66c530840139.png) ![old-980](https://user-images.githubusercontent.com/1732117/212223527-05ebe774-6482-4038-b0a6-72819beee922.png)
![new-5](https://user-images.githubusercontent.com/1732117/212223523-53ec9983-f998-4c53-b432-e8fcac93942a.png) ![new-980](https://user-images.githubusercontent.com/1732117/212223524-6fd84f70-51d4-4da7-b441-0b5d7ac4cd2d.png)
![diff-5](https://user-images.githubusercontent.com/1732117/212223529-fca06e90-805c-4447-93cb-735487c186db.png) ![diff-980](https://user-images.githubusercontent.com/1732117/212223530-ef941b63-39b1-4cbd-b0e8-91e7ffd69c34.png)
