### PR TITLE
Bump version of npm shield library

### DIFF
--- a/shieldlib/package.json
+++ b/shieldlib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@americana/maplibre-shield-generator",
   "description": "Generate highway shields for maplibre-gl-js maps",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "OpenStreetMap Americana Contributors",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Bumps the version of the npm shield library in order to publish updated docs with the new repository links.
I've already published the new library with this version change.