### PR TITLE
Update retagged shield definitions

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3199,7 +3199,7 @@ export function loadShields() {
   // AFRICA
 
   // Algeria
-  shields["DZ:highway"] = shields["DZ:national"] = roundedRectShield(
+  shields["DZ:motorway"] = shields["DZ:national"] = roundedRectShield(
     Color.shields.red,
     Color.shields.white
   );
@@ -3383,7 +3383,7 @@ export function loadShields() {
   };
 
   // Iran
-  shields["ir:freeways"] = roundedRectShield(
+  shields["ir:freeway"] = roundedRectShield(
     Color.shields.blue,
     Color.shields.white
   );
@@ -3569,11 +3569,11 @@ export function loadShields() {
   );
 
   // Vietnam
-  shields["vn:expressway"] = roundedRectShield(
+  shields["VN:expressway"] = roundedRectShield(
     Color.shields.yellow,
     Color.shields.black
   );
-  shields["vn:national"] = roundedRectShield(
+  shields["VN:national"] = roundedRectShield(
     Color.shields.white,
     Color.shields.black
   );
@@ -3947,13 +3947,12 @@ export function loadShields() {
   );
 
   // Poland
-  shields["pl:motorways"] = roundedRectShield(
+  shields["pl:expressway"] = shields["pl:motorway"] = roundedRectShield(
     Color.shields.red,
     Color.shields.white,
     Color.shields.white,
     34
   );
-  shields["pl:expressways"] = shields["pl:motorways"];
   shields["pl:national"] = roundedRectShield(
     Color.shields.red,
     Color.shields.white


### PR DESCRIPTION
These routes have largely been retagged since initial support in Americana. Algeria renamed `highway` to `motorway`, Iran and Poland switched to the singular form, and Vietnam capitalized its country code.