### PR TITLE
Add shield for Utah Federal Aid routes

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2873,7 +2873,7 @@ export function loadShields() {
       bottom: 5,
     },
   };
-  ["Wayne", "Washington"].forEach(
+  ["FA", "Washington"].forEach(
     (county) =>
       (shields[`US:UT:${county}`] = pentagonUpShield(
         3,


### PR DESCRIPTION
Federal Aid routes of Utah do not have guide signs, but are sometimes signed with mileposts that include the route number in a pentagonal "county" shield.

The definition for `network=US:UT:Wayne` is removed here because it was a mistagging by yours truly, corrected [here.](https://www.openstreetmap.org/changeset/156846582)