### PR TITLE
Add dark mode using CSS 'filter: invert hue-rotate' trick

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,6 +22,14 @@
         bottom: 0;
         width: 100%;
       }
+
+      /* quick and dirty dark mode hack */
+      @media (prefers-color-scheme: dark) {
+        #map {
+          filter: invert(1) hue-rotate(180deg) saturate(75%);
+        }
+      }
+
       #attribution-logo {
         position: absolute;
         bottom: 10px;


### PR DESCRIPTION
This is a quick and dirty hack to support a dark mode style on americanamap.org. It uses a CSS `filter` to invert and hue-rotate the default style.