### PR TITLE
Fixes icon links for capital icons in taginfo

### DIFF
--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -21,7 +21,7 @@
       "object_types": ["node"],
       "description": "Marks the city with a national capital icon.",
       "doc_url": "https://openmaptiles.org/schema/#capital",
-      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/star_nation_capital.svg"
+      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/place_star_in_circle.svg"
     },
     {
       "key": "capital",
@@ -29,7 +29,7 @@
       "object_types": ["node"],
       "description": "Marks the city with a national capital icon.",
       "doc_url": "https://openmaptiles.org/schema/#capital",
-      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/star_nation_capital.svg"
+      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/place_star_in_circle.svg"
     },
     {
       "key": "capital",
@@ -37,7 +37,7 @@
       "object_types": ["node"],
       "description": "Marks the city with a state capital icon.",
       "doc_url": "https://openmaptiles.org/schema/#capital",
-      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/star_state_capital.svg"
+      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/place_star.svg"
     },
     {
       "key": "capital",
@@ -45,7 +45,7 @@
       "object_types": ["node"],
       "description": "Marks the city with a state capital icon.",
       "doc_url": "https://openmaptiles.org/schema/#capital",
-      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/star_state_capital.svg"
+      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/place_star.svg"
     },
     {
       "key": "capital",


### PR DESCRIPTION
Fixes #1145. Repairs links to icons for national and state capitals in taginfo. I didn't catch any other dead links during a brief look through.