### PR TITLE
Add Bolivia national shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -118,6 +118,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .ht,
 .mx,
 .us,
+.bo,
 .cl,
 .co,
 .uy,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -670,7 +670,6 @@ export function loadShields() {
   shields["US:I:Business:Spur"] = shields["US:I:Business:Loop"];
   shields["US:I:Downtown:Loop"] = shields["US:I:Business:Loop"];
   shields["US:I:Downtown:Spur"] = shields["US:I:Business:Spur"];
-  shields["BO:fundamental"] = shields["US:I:Business:Loop"];
 
   // US Highways
   shields["US:US"] = {
@@ -3141,6 +3140,14 @@ export function loadShields() {
       top: 3,
       bottom: 7,
     },
+  };
+
+  // Bolivia
+  shields["BO:fundamental"] = {
+    ...badgeShieldCrossbar,
+    colorDarken: Color.shields.green,
+    colorLighten: Color.shields.white,
+    textColor: Color.shields.white,
   };
 
   // Uruguay

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -670,6 +670,7 @@ export function loadShields() {
   shields["US:I:Business:Spur"] = shields["US:I:Business:Loop"];
   shields["US:I:Downtown:Loop"] = shields["US:I:Business:Loop"];
   shields["US:I:Downtown:Spur"] = shields["US:I:Business:Spur"];
+  shields["BO:fundamental"] = shields["US:I:Business:Loop"];
 
   // US Highways
   shields["US:US"] = {


### PR DESCRIPTION
This pull requests adds road shields for Bolivia's national route network. I can't find any evidence that these shields are used on the ground, but they are used in cartographic representations of the road network. National legislation also outlines designs for departmental and municipal route shields (see below), but I can't find any evidence that those are used in any context.

I've chosen just to reuse the green US interstate business route shield for simplicity's sake.

![Screenshot 2024-10-15 at 5 55 50 AM](https://github.com/user-attachments/assets/2d25aec9-7526-40da-9e0c-99d58d4c6469)

[localhost link](http://localhost:1776/#map=10.47/-17.9538/-67.0857)
![Screenshot 2024-11-26 at 6 10 18 AM](https://github.com/user-attachments/assets/a939762d-feaf-4737-9ab7-0985794ab115)

[departmental map of Oruro](https://www.abc.gob.bo/wp-content/uploads/2018/08/MAPA_ORURO_2018.pdf)
![Screenshot 2024-11-26 at 6 10 29 AM](https://github.com/user-attachments/assets/99879992-3092-4cdf-9874-4cd660558715)
