### PR TITLE
Fix banner definitions for several route networks [BUGFIX]

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -639,7 +639,7 @@ export function loadShields() {
   // United States
 
   // Interstate Highways
-  shields["US:I"] = {
+  const usInterstateShield = {
     spriteBlank: ["shield_us_interstate_2", "shield_us_interstate_3"],
     textLayout: textConstraint("southHalfEllipse"),
     textColor: Color.shields.white,
@@ -649,6 +649,9 @@ export function loadShields() {
       top: 6,
       bottom: 5,
     },
+  }
+  shields["US:I"] = {
+    ...usInterstateShield,
     bannerMap: {
       "US:I:Alternate": ["ALT"],
       "US:I:Express": ["EXPR"],
@@ -660,7 +663,7 @@ export function loadShields() {
   };
 
   shields["US:I:Business:Loop"] = {
-    ...shields["US:I"],
+    ...usInterstateShield,
     spriteBlank: [
       "shield_us_interstate_business_2",
       "shield_us_interstate_business_3",
@@ -1457,7 +1460,7 @@ export function loadShields() {
   };
 
   // Maryland
-  shields["US:MD"] = {
+  const marylandShield = {
     spriteBlank: ["shield_us_md_2", "shield_us_md_3"],
     textColor: Color.shields.black,
     padding: {
@@ -1466,6 +1469,10 @@ export function loadShields() {
       top: 6,
       bottom: 2,
     },
+  }
+
+  shields["US:MD"] = {
+    ...marylandShield,
     bannerMap: {
       "US:MD:Alternate": ["ALT"],
       "US:MD:Bypass": ["BYP"],
@@ -1473,7 +1480,7 @@ export function loadShields() {
   };
   shields["US:MD:Business"] = banneredShield(
     {
-      ...shields["US:MD"],
+      ...marylandShield,
       textColor: Color.shields.green,
       colorLighten: Color.shields.green,
     },
@@ -2097,7 +2104,7 @@ export function loadShields() {
   );
 
   // New York
-  shields["US:NY"] = {
+  const usNewYorkShield = {
     spriteBlank: ["shield_us_ny_2", "shield_us_ny_3"],
     textColor: Color.shields.black,
     padding: {
@@ -2106,6 +2113,9 @@ export function loadShields() {
       top: 5,
       bottom: 5,
     },
+  }
+  shields["US:NY"] = {
+    ...usNewYorkShield,
     bannerMap: {
       "US:NY:Truck": ["TRK"],
     },
@@ -2124,8 +2134,8 @@ export function loadShields() {
       top: 3,
       bottom: 3,
     },
+    ref: "LOOP"
   };
-  shields["US:NY:Inner_Loop"].ref = "LOOP";
   shields["US:NY:Thruway"] = {
     noref: {
       spriteBlank: "shield_us_ny_thruway",
@@ -2137,7 +2147,7 @@ export function loadShields() {
     },
   };
   shields["US:NY:Parkway"] = {
-    ...shields["US:NY"],
+    ...usNewYorkShield,
     textColor: Color.shields.white,
     colorLighten: Color.shields.white,
     colorDarken: Color.shields.green,
@@ -2704,6 +2714,18 @@ export function loadShields() {
   );
 
   // Texas
+  const usTexasShapedShield = {
+    spriteBlank: "shield_us_tx_outline",
+    textColor: Color.shields.black,
+    textLayout: textConstraint("ellipse"),
+    padding: {
+      left: 3,
+      right: 0,
+      top: 7,
+      bottom: 10,
+    },
+  }
+
   shields["US:TX"] = {
     ...roundedRectShield(Color.shields.white, Color.shields.black),
     bannerMap: {
@@ -2717,22 +2739,14 @@ export function loadShields() {
     },
   };
   shields["US:TX:FM"] = shields["US:TX:RM"] = {
-    spriteBlank: "shield_us_tx_outline",
-    textColor: Color.shields.black,
-    textLayout: textConstraint("ellipse"),
-    padding: {
-      left: 3,
-      right: 0,
-      top: 7,
-      bottom: 10,
-    },
+    ...usTexasShapedShield,
     bannerMap: {
       "US:TX:FM:Business": ["BUS"],
     },
   };
   shields["US:TX:Recreational"] = banneredShield(
     {
-      ...shields["US:TX:FM"],
+      ...usTexasShapedShield,
       textColor: Color.shields.brown,
       colorLighten: Color.shields.brown,
     },
@@ -2751,10 +2765,7 @@ export function loadShields() {
       "US:TX:Loop:Express:Toll": ["EXPR", "LOOP"],
     },
   };
-  shields["US:TX:Toll"] = shields["US:TX:NTTA"] = roundedRectShield(
-    Color.shields.blue,
-    Color.shields.white
-  );
+
   shields["US:TX:CTRMA"] = {
     ...roundedRectShield(
       Color.shields.blue,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -649,7 +649,7 @@ export function loadShields() {
       top: 6,
       bottom: 5,
     },
-  }
+  };
   shields["US:I"] = {
     ...usInterstateShield,
     bannerMap: {
@@ -1469,7 +1469,7 @@ export function loadShields() {
       top: 6,
       bottom: 2,
     },
-  }
+  };
 
   shields["US:MD"] = {
     ...marylandShield,
@@ -2113,7 +2113,7 @@ export function loadShields() {
       top: 5,
       bottom: 5,
     },
-  }
+  };
   shields["US:NY"] = {
     ...usNewYorkShield,
     bannerMap: {
@@ -2134,7 +2134,7 @@ export function loadShields() {
       top: 3,
       bottom: 3,
     },
-    ref: "LOOP"
+    ref: "LOOP",
   };
   shields["US:NY:Thruway"] = {
     noref: {
@@ -2724,7 +2724,7 @@ export function loadShields() {
       top: 7,
       bottom: 10,
     },
-  }
+  };
 
   shields["US:TX"] = {
     ...roundedRectShield(Color.shields.white, Color.shields.black),


### PR DESCRIPTION
Fixes #1160 

This PR fixes the definitions of several route networks which copied from a parent route network.  Since the parent route network had banners defined, the child network inappropriately inherited those banners.  This fixes the issue for these routes by separating out the style components of reusable networks into separate constants. 