### PR TITLE
Add shields for Arapahoe and Jefferson Counties, Colorado

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1055,12 +1055,14 @@ export function loadShields() {
     },
   };
   [
+    "Arapahoe",
     "Archuleta",
     "Chaffee",
     "Conejos",
     "Grand",
     "Gunnison",
     "Jackson",
+    "Jefferson",
     "Lake",
     "La_Plata",
     "Larimer",


### PR DESCRIPTION
Fixes #1175.

[Arapahoe County](https://www.bing.com/maps?cp=39.594441%7E-104.796679&lvl=19.3&mo=om.1&pi=1.9&style=x&dir=31.7) and [Jefferson County](https://www.bing.com/maps?cp=39.655983%7E-105.191436&lvl=22.0&pi=-1.6&style=x&dir=34.6) both have at least one route signed with a blue pentagon shield.