### PR TITLE
Remove padding from the default shield for unknown networks

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -94,12 +94,6 @@ export function loadShields() {
   shields["default"] = {
     textColor: Color.shields.black,
     textHaloColor: Color.backgroundFill,
-    padding: {
-      left: 3,
-      right: 3,
-      top: 3,
-      bottom: 3,
-    },
   };
 
   // NORTH AMERICA


### PR DESCRIPTION
This avoids wasting space (on each side, 3 pixels were reserved for the shield, but never actually used) and avoids unnecessarily small font sizes (e.g. 4-character refs are now much more readable).