### PR TITLE
overrideByName causes legend to omit shields #1165

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=18 <=20",
         "npm": ">=8.3.0"
       }
     },
@@ -6300,7 +6300,7 @@
     },
     "shieldlib": {
       "name": "@americana/maplibre-shield-generator",
-      "version": "0.0.5",
+      "version": "0.0.7",
       "license": "CC0-1.0",
       "dependencies": {
         "@types/node": "^20.8.4",

--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -486,8 +486,12 @@ export default class LegendControl {
             shieldDef.overrideByName[image.name].spriteBlank;
         }
       } else if (!networkImages.ref && image.ref) {
+        // Store the numbered variant of a shield if required by the shield
+        // definition.
         networkImages.ref = image.imageName;
       } else if (!networkImages.noRef && !image.ref) {
+        // Store the unnumbered variant of a shield if required by the shield
+        // definition.
         networkImages.noRef = image.imageName;
       }
 

--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -507,7 +507,7 @@ export default class LegendControl {
       let images = imagesByNetwork[network];
       if (!images) return [];
       return [
-        images.noRef,
+        Object.values(images.overridesByName).length > 0 ? "" : images.noRef,
         images.ref,
         ...Object.values(images.overridesByRef),
         ...Object.values(images.overridesByName), // Add overrides by name

--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -466,7 +466,10 @@ export default class LegendControl {
     let unrecognizedNetworks = new Set();
     for (let image of images) {
       if (!(image.network in imagesByNetwork)) {
-        imagesByNetwork[image.network] = { overridesByRef: {} };
+        imagesByNetwork[image.network] = {
+          overridesByRef: {},
+          overridesByName: {},
+        };
       }
       let networkImages = imagesByNetwork[image.network];
 
@@ -476,13 +479,15 @@ export default class LegendControl {
         if (!networkImages.overridesByRef[image.ref]) {
           networkImages.overridesByRef[image.ref] = image.imageName;
         }
+      } else if (image.name && shieldDef?.overrideByName?.[image.name]) {
+        // Store a different image for each override in the shield definition.
+        if (!networkImages.overridesByName[image.name]) {
+          networkImages.overridesByName[image.name] =
+            shieldDef.overrideByName[image.name].spriteBlank;
+        }
       } else if (!networkImages.ref && image.ref) {
-        // Store the numbered variant of a shield if required by the shield
-        // definition.
         networkImages.ref = image.imageName;
       } else if (!networkImages.noRef && !image.ref) {
-        // Store the unnumbered variant of a shield if required by the shield
-        // definition.
         networkImages.noRef = image.imageName;
       }
 
@@ -501,6 +506,7 @@ export default class LegendControl {
         images.noRef,
         images.ref,
         ...Object.values(images.overridesByRef),
+        ...Object.values(images.overridesByName), // Add overrides by name
       ].filter((i) => i);
     };
 

--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -510,7 +510,7 @@ export default class LegendControl {
         Object.values(images.overridesByName).length > 0 ? "" : images.noRef,
         images.ref,
         ...Object.values(images.overridesByRef),
-        ...Object.values(images.overridesByName), // Add overrides by name
+        ...Object.values(images.overridesByName),
       ].filter((i) => i);
     };
 


### PR DESCRIPTION
Hi @1ec5 

I have implemented a fix for this issue. The updated logic ensures that shields appear correctly in the legend even when a network uses `overrideByName`. Specifically, the `getSortedImages` function now accounts for `overrideByName` alongside existing overrides, ensuring no blank spaces are shown.

Let me know if this solution meets your expectations or if further adjustments are needed.

![Screenshot 2024-12-16 at 3 30 17 PM](https://github.com/user-attachments/assets/7307126e-efb2-47ce-8459-646e023d717f)
