### PR TITLE
make triangle shield more rounded

### DIFF
--- a/shieldlib/src/shield_helper.ts
+++ b/shieldlib/src/shield_helper.ts
@@ -217,7 +217,7 @@ export function triangleDownShield(
   rectWidth: number
 ): Partial<ShieldDefinition> {
   textColor = textColor ?? strokeColor;
-  radius = radius ?? 2;
+  radius = radius ?? 3;
 
   return {
     shapeBlank: {
@@ -232,10 +232,10 @@ export function triangleDownShield(
     },
     textLayout: textConstraint("triangleDown"),
     padding: {
-      left: 1,
-      right: 1,
-      top: 2,
-      bottom: 1,
+      left: 0,
+      right: 0,
+      top: 3,
+      bottom: 0,
     },
     textColor,
   };


### PR DESCRIPTION
The current triangle shield looks too pointy compared to the [real signs in Tennessee](https://kartaview.org/map/@36.20901929433252,-86.27649482614521,19z). This PR gives them a bigger curve radius and realigns the inlaid text.

![image](https://github.com/user-attachments/assets/b9bb6b76-5327-485d-9e53-6a4486ca19ce)

[before](http://americanamap.org/#map=12.56/36.42448/-89.066)/[after](https://preview.ourmap.us/pr/1182/#map=12.56/36.42448/-89.066):

![image](https://github.com/user-attachments/assets/6c40132e-3326-4a42-9d16-30f36765365a)

![image](https://github.com/user-attachments/assets/475a55a1-fe9a-47d6-b3c9-1ae5ef62202f)
