### PR TITLE
maplibre-shield-generator v0.1.0

### DIFF
--- a/shieldlib/package.json
+++ b/shieldlib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@americana/maplibre-shield-generator",
   "description": "Generate highway shields for maplibre-gl-js maps",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "author": "OpenStreetMap Americana Contributors",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Updated the NPM package file for maplibre-shield-generator v0.1.0 to unbreak external clients that use the style JSON with this library.

The patch version is usually for extenuating circumstances or very minor changes. I bumped the minor version instead to signal that there’s a slight potential for incompatibility with anything that was coded against the previous version.