### PR TITLE
Add shields for Weld County, Colorado

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1073,6 +1073,7 @@ export function loadShields() {
     "Saguache",
     "San_Juan",
     "Teller",
+    "Weld",
   ].forEach(
     (county) =>
       (shields[`US:CO:${county}`] = pentagonUpShield(


### PR DESCRIPTION
Fixes #1197.

Follow-up to #988, #1039.