### PR TITLE
Fixing capitalization of Iran highway network tagging

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3455,8 +3455,12 @@ export function loadShields() {
   };
 
   // Iran
-  shields["ir:freeway"] = roundedRectShield(
+  shields["IR:freeway"] = roundedRectShield(
     Color.shields.blue,
+    Color.shields.white
+  );
+  shields["IR:national"] = roundedRectShield(
+    Color.shields.green,
     Color.shields.white
   );
 

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3459,10 +3459,6 @@ export function loadShields() {
     Color.shields.blue,
     Color.shields.white
   );
-  shields["IR:national"] = roundedRectShield(
-    Color.shields.green,
-    Color.shields.white
-  );
 
   // Iraq
   shields["IQ:national"] = roundedRectShield(


### PR DESCRIPTION
It looks like highway relations in Iran were updated to use the capitalized `IR` last August, so this PR updates the shield definition to align with that. I've also added shields for the second tier of road relations in Iran, which are tagged as `IR:national` and are green.

Example of roads tagged with `IR:national`
![Screenshot 2025-03-16 at 7 38 31 AM](https://github.com/user-attachments/assets/084b0293-56c2-419c-811f-d0a916228e54)

[Localhost link](http://localhost:1776/#map=9.03/34.7282/51.0156)
![Screenshot 2025-03-16 at 7 42 06 AM](https://github.com/user-attachments/assets/59666bcb-ef7d-42b8-8502-6702fa0455bc)

