### PR TITLE
Add initialism for Bear Mountain Parkway

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2157,6 +2157,7 @@ export function loadShields() {
     colorLighten: Color.shields.white,
     colorDarken: Color.shields.green,
     refsByName: {
+      "Bear Mountain Parkway": "BMP",
       "Bear Mountain State Parkway": "BMP",
       "Bronx River Parkway": "BRP",
       "Cross County Parkway": "CCP",


### PR DESCRIPTION
The name in OSM was changed to remove the "State" from "Bear Mountain State Parkway", since it is usually omitted in speech and is not signed on the ground at all. However, since it is possible that someone might change it back, this commit does not remove the mapping for the old name.