### PR TITLE
Add contributor guidelines to recommend links/screenshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,9 @@ boilerplate in `scripts/taginfo_template.json`.
    browser environment, add automated unit tests for it to `test/spec/`, then
    run `npm test` to ensure that they pass. This project structures unit tests
    using [Chai](https://www.chaijs.com/guide/styles/) for assertions.
+6. There are built-in GitHub actions that will generate a preview map of your
+   changes. We recommend initially creating a PR draft, and then using the preview
+   map to capture links and screenshots to add to your PR.
 
 [90]: https://prettier.io/
 [svgo]: https://github.com/svg/svgo/


### PR DESCRIPTION
This PR adds a suggestion to visit the map preview and collect screen shots for PRs. There is nothing that obviously tells a new contributor that they can do this and that it would be helpful to provide screen shots.

Additional suggestions for the text?