### PR TITLE
Make sure a shape or sprite is specified for notext shields

### DIFF
--- a/shieldlib/src/shield.ts
+++ b/shieldlib/src/shield.ts
@@ -271,11 +271,14 @@ function getShieldDef(
 
   //Determine whether a route without a ref gets drawn
   if (
+    //If the ref is missing
     !isValidRef(ref) &&
-    !shieldDef.notext &&
     !shieldDef.ref &&
-    !(shieldDef.refsByName && routeDef.name)
+    !(shieldDef.refsByName && routeDef.name) &&
+    //then the def must be marked as displayable without text and have a sprite or shape specified
+    (!shieldDef.notext || (!shieldDef.spriteBlank && !shieldDef.shapeBlank))
   ) {
+    //or else don't draw a shield
     return null;
   }
 


### PR DESCRIPTION
This fixes an issue where blank shields could show up when the definition has no ref, notext=true, but is missing a sprite blank. For example, this definition seems valid:

```
shields["US:NHT"] = {
    notext: true,
    overrideByName: {
      "Oregon National Historic Trail Auto Tour Route": {
        spriteBlank: "shield_us_nht_oreg",
      },
      "Overmountain Victory National Historic Trail Commemorative Motor Route":
        {
          spriteBlank: "shield_us_nht_ovvi",
        },
      "Selma to Montgomery National Historic Trail": {
        spriteBlank: "shield_us_nht_semo",
      },
    },
  };
```

But Americana would output a blank space for any route with `network=US:NHT` but a name not specified here. This particular case could also be fixed by moving `notext: true` inside the `overrideByName ` defs, but this adds duplication.

Here is a section of the Columbia River Highway before the change. The Lewis and Clark NHT is tagged but does not have a shield yet, resulting in a blank space.

<img width="255" alt="Screenshot 2025-06-16 at 11 50 54 AM" src="https://github.com/user-attachments/assets/61615c69-1cc8-446a-bf05-094e09671a11" />

After there change this looks as expected:

<img width="265" alt="Screenshot 2025-06-16 at 12 17 11 PM" src="https://github.com/user-attachments/assets/e2bf2d51-830a-4da6-a4ac-e8c38a77b6b6" />
