### PR TITLE
Add ALT banner to NYS scenic byway alternate routes

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -2217,6 +2217,9 @@ export function loadShields() {
   };
   shields["US:NY:Scenic"] = {
     notext: true,
+    bannerMap: {
+      "US:NY:Scenic:Alternate": ["ALT"],
+    },
     overrideByName: {
       "Adirondack Trail": {
         spriteBlank: "shield_us_ny_scenic_adirondack",


### PR DESCRIPTION
There's only one NYS scenic route currently supported by Americana that has an alternate route but there will be a few more later.

#map=13.43/44.46907/-75.34078

<img width="409" height="285" alt="Screenshot 2025-07-11 at 4 36 25 PM" src="https://github.com/user-attachments/assets/962164c9-b4cd-4c8f-a7b1-53b448fa47c0" />