### PR TITLE
Deploy script for new tab for icon changes

### DIFF
--- a/.github/workflows/deploy-pr-checks.yml
+++ b/.github/workflows/deploy-pr-checks.yml
@@ -141,3 +141,19 @@ jobs:
           output: |
             {"summary":"Style size changes introduced by this PR", "title":"View metrics on style size changes"}
           output_text_description_file: stats-difference.md
+      - name: Create empty icon-changes.md if not exists
+        run: |
+          if [ ! -f icon-changes.md ]; then
+            echo "No icon changes detected in this PR." > icon-changes.md
+          fi
+      - name: Print Icon Changes to GitHub Checks
+        uses: LouisBrunner/checks-action@v2.0.0
+        if: always()
+        with:
+          sha: ${{ env.PR_SHA }}
+          token: ${{ steps.checks_token.outputs.token }}
+          name: Icon Changes
+          conclusion: neutral
+          output: |
+            {"summary":"Icon changes and pixel alignment previews", "title":"View icon grid previews for changed icons"}
+          output_text_description_file: icon-changes.md


### PR DESCRIPTION
This PR adds the deploy code for a new tab for icon changes.  This modifies the _privileged_ deploy script, which has access to GitHub secrets.  After this change, I'll be able to post a separate PR, #1226, which will actually generate the icon change images and post the to the tab, and we'll be able to review that process and see how the output looks.

This change is only to add the little script bit that uploads the new tab's contents.