### PR TITLE
Add fully-qualified URLs to icon change files in CI

### DIFF
--- a/.github/workflows/deploy-pr-checks.yml
+++ b/.github/workflows/deploy-pr-checks.yml
@@ -141,10 +141,14 @@ jobs:
           output: |
             {"summary":"Style size changes introduced by this PR", "title":"View metrics on style size changes"}
           output_text_description_file: stats-difference.md
-      - name: Create empty icon-changes.md if not exists
+      - name: Add fully qualified URLs to icon-changes.md for GitHub checks
         run: |
-          if [ ! -f icon-changes.md ]; then
-            echo "No icon changes detected in this PR." > icon-changes.md
+          if [ -f icon-grids/icon-changes.md ]; then
+            # Copy the file and replace relative paths with absolute URLs
+            sed "s|icon-grids/|https://preview.americanamap.org/pr/${{ env.PR_NUM }}/icon-grids/|g" icon-grids/icon-changes.md > icon-changes.md
+            echo "Icon changes markdown created with absolute URLs"
+          else
+            echo "No icon change file found in this PR."
           fi
       - name: Print Icon Changes to GitHub Checks
         uses: LouisBrunner/checks-action@v2.0.0


### PR DESCRIPTION
This PR adds code to the privileged deploy script to generate fully-qualified URLs in the icon-grids previews. This must be in the privileged runner in order to get access to the PR number. This will not show in preview because the privileged runner only runs from the main branch.