### PR TITLE
[BUGFIX] Fix paths for icon grid CI

### DIFF
--- a/.github/workflows/deploy-pr-checks.yml
+++ b/.github/workflows/deploy-pr-checks.yml
@@ -148,7 +148,7 @@ jobs:
             sed "s|icon-grids/|https://preview.americanamap.org/pr/${{ env.PR_NUM }}/icon-grids/|g" icon-grids/icon-changes.md > icon-changes.md
             echo "Icon changes markdown created with absolute URLs"
           else
-            echo "No icon change file found in this PR."
+            echo "No icon change file found in this PR." > icon-changes.md
           fi
       - name: Print Icon Changes to GitHub Checks
         uses: LouisBrunner/checks-action@v2.0.0
@@ -160,4 +160,4 @@ jobs:
           conclusion: neutral
           output: |
             {"summary":"Icon changes and pixel alignment previews", "title":"View icon grid previews for changed icons"}
-          output_text_description_file: icon-changes.md
+          output_text_description_file: icon-grids/icon-changes.md


### PR DESCRIPTION
1. Ensure that there's always an icon-grid file
2. Make sure paths are correct (icon-grid files are put in the icon-grid folder)