### PR TITLE
Add 3x sprites

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -45,6 +45,10 @@ jobs:
           npm run shields
           cp src/configs/config.aws.js src/config.js
         working-directory: main
+      - name: Generate sprites for main branch using PR branch script
+        run: |
+          node ../pr-branch/scripts/sprites.js
+        working-directory: main
       - name: Setup Node.js for building pr branch
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -63,7 +63,7 @@ jobs:
         working-directory: pr-branch
       - name: Generate sprites for main branch using PR branch script
         run: |
-          node scripts/sprites.js -i ../main/icons -o ../main/dist/sprites
+          npm run sprites -i ../main/icons -o ../main/dist/sprites
         working-directory: pr-branch
       - name: Capture main branch usage statistics
         id: main-stats

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -45,10 +45,6 @@ jobs:
           npm run shields
           cp src/configs/config.aws.js src/config.js
         working-directory: main
-      - name: Generate sprites for main branch using PR branch script
-        run: |
-          node scripts/sprites.js -i ../main/icons -o ../main/dist/sprites
-        working-directory: pr-branch
       - name: Setup Node.js for building pr branch
         uses: actions/setup-node@v4
         with:
@@ -64,6 +60,10 @@ jobs:
           mkdir -p dist/shield-docs
           cp -r shieldlib/docs/* dist/shield-docs
           mv dist ..
+        working-directory: pr-branch
+      - name: Generate sprites for main branch using PR branch script
+        run: |
+          node scripts/sprites.js -i ../main/icons -o ../main/dist/sprites
         working-directory: pr-branch
       - name: Capture main branch usage statistics
         id: main-stats

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -47,8 +47,8 @@ jobs:
         working-directory: main
       - name: Generate sprites for main branch using PR branch script
         run: |
-          node ../pr-branch/scripts/sprites.js
-        working-directory: main
+          node scripts/sprites.js -i ../main/icons -o ../main/dist/sprites
+        working-directory: pr-branch
       - name: Setup Node.js for building pr branch
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -63,7 +63,7 @@ jobs:
         working-directory: pr-branch
       - name: Generate sprites for main branch using PR branch script
         run: |
-          npm run sprites -i ../main/icons -o ../main/dist/sprites
+          npm run sprites -- -i ../main/icons -o ../main/dist/sprites
         working-directory: pr-branch
       - name: Capture main branch usage statistics
         id: main-stats

--- a/.github/workflows/deploy-pr-checks.yml
+++ b/.github/workflows/deploy-pr-checks.yml
@@ -96,6 +96,13 @@ jobs:
           responseCode: "200"
           timeout: 120000
           interval: 500
+      - name: Wait for PR Preview Upload (3x Sprite)
+        uses: cygnetdigital/wait_for_response@v2.0.0
+        with:
+          url: "https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite@3x.png"
+          responseCode: "200"
+          timeout: 120000
+          interval: 500
       - name: Generate Preview text
         run: |
           echo "## Live PR Preview:
@@ -111,6 +118,7 @@ jobs:
 
           <img src="https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite.png" />
           <img src="https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite@2x.png" />
+          <img src="https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite@3x.png" />
           " > pr_preview.md
           [ -f pr_preview-extra.md ] && cat pr_preview-extra.md >> pr_preview.md || echo "No extra PR preview found."
       - uses: tibdex/github-app-token@v1

--- a/.github/workflows/deploy-pr-checks.yml
+++ b/.github/workflows/deploy-pr-checks.yml
@@ -116,9 +116,9 @@ jobs:
 
           ## Sprite Sheets:
 
-          <img src="https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite.png" />
-          <img src="https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite@2x.png" />
-          <img src="https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite@3x.png" />
+          <img src="https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite.png" alt="1x sprite sheet" />
+          <img src="https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite@2x.png" alt="2x sprite sheet" />
+          <img src="https://preview.americanamap.org/pr/${{ env.PR_NUM }}/sprites/sprite@3x.png" alt="3x sprite sheet" />
           " > pr_preview.md
           [ -f pr_preview-extra.md ] && cat pr_preview-extra.md >> pr_preview.md || echo "No extra PR preview found."
       - uses: tibdex/github-app-token@v1

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The dynamic shield generator is included as a [module](shieldlib/README.md) in t
 
 ## Artifacts
 
-- Style users can use the maplibre [StyleJSON](https://americanamap.org/style.json), and sprite sheets ([1x](https://americanamap.org/sprites/sprite.png), [2x](https://americanamap.org/sprites/sprite@2x.png)).
+- Style users can use the maplibre [StyleJSON](https://americanamap.org/style.json), and sprite sheets ([1x](https://americanamap.org/sprites/sprite.png), [2x](https://americanamap.org/sprites/sprite@2x.png), [3x](https://americanamap.org/sprites/sprite@3x.png)).
 - For highway shield library users, a [ShieldJSON](https://americanamap.org/shields.json) must be supplied to associate route networks with sprite images and drawn shield shapes.
 - The project [taginfo.json](https://americanamap.org/taginfo.json) lists which tags are used by the style.
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "presprites": "shx rm -rf dist/sprites",
     "serve": "tsx scripts/serve",
     "shields": "node scripts/generate_shield_defs.js -o dist/shields.json",
-    "sprites": "node scripts/sprites.js",
+    "sprites": "tsx scripts/sprites.ts",
     "start": "run-s clean-build build:shieldlib sprites shields serve",
     "stats": "node scripts/stats.js",
     "style": "node scripts/generate_style.js -o dist/style.json",

--- a/scripts/sprites.js
+++ b/scripts/sprites.js
@@ -7,7 +7,11 @@ import { Command } from "commander";
 const program = new Command();
 program
   .option("-i, --icons <path>", "path to icons directory", "./icons")
-  .option("-o, --output <path>", "output directory for sprites", "./dist/sprites")
+  .option(
+    "-o, --output <path>",
+    "output directory for sprites",
+    "./dist/sprites"
+  )
   .parse(process.argv);
 
 const opts = program.opts();

--- a/scripts/sprites.js
+++ b/scripts/sprites.js
@@ -1,14 +1,22 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-
 import { glob } from "glob";
 import { Sprites } from "@basemaps/sprites";
+import { Command } from "commander";
 
-await fs.mkdir("./dist/sprites/", { recursive: true });
+const program = new Command();
+program
+  .option("-i, --icons <path>", "path to icons directory", "./icons")
+  .option("-o, --output <path>", "output directory for sprites", "./dist/sprites")
+  .parse(process.argv);
+
+const opts = program.opts();
+
+await fs.mkdir(opts.output, { recursive: true });
 
 const sprites = await Promise.all(
   (
-    await glob("./icons/*.svg")
+    await glob(`${opts.icons}/*.svg`)
   ).map(async (spritePath) => {
     const id = path.parse(spritePath).name;
     const buffer = await fs.readFile(spritePath);
@@ -16,14 +24,14 @@ const sprites = await Promise.all(
   })
 );
 
-console.log(`Building ${sprites.length} sprites`);
+console.log(`Building ${sprites.length} sprites from ${opts.icons}`);
 
 const generated = await Sprites.generate(sprites, [1, 2, 3]);
 
 for (const result of generated) {
   const scaleText = result.pixelRatio === 1 ? "" : `@${result.pixelRatio}x`;
-  const outputPng = `./dist/sprites/sprite${scaleText}.png`;
-  const outputJson = `./dist/sprites/sprite${scaleText}.json`;
+  const outputPng = `${opts.output}/sprite${scaleText}.png`;
+  const outputJson = `${opts.output}/sprite${scaleText}.json`;
 
   await fs.writeFile(outputPng, result.buffer);
   await fs.writeFile(outputJson, JSON.stringify(result.layout, null, 2));

--- a/scripts/sprites.js
+++ b/scripts/sprites.js
@@ -18,7 +18,7 @@ const sprites = await Promise.all(
 
 console.log(`Building ${sprites.length} sprites`);
 
-const generated = await Sprites.generate(sprites, [1, 2]);
+const generated = await Sprites.generate(sprites, [1, 2, 3]);
 
 for (const result of generated) {
   const scaleText = result.pixelRatio === 1 ? "" : `@${result.pixelRatio}x`;

--- a/scripts/sprites.ts
+++ b/scripts/sprites.ts
@@ -30,7 +30,10 @@ const sprites: SvgId[] = await Promise.all(
 
 console.log(`Building ${sprites.length} sprites from ${opts.icons}`);
 
-const generated: SpriteSheetResult[] = await Sprites.generate(sprites, [1, 2, 3]);
+const generated: SpriteSheetResult[] = await Sprites.generate(
+  sprites,
+  [1, 2, 3]
+);
 
 for (const result of generated) {
   const scaleText: string =
@@ -42,4 +45,4 @@ for (const result of generated) {
   await fs.writeFile(outputJson, JSON.stringify(result.layout, null, 2));
   const kb: string = (result.buffer.length / 1024).toFixed(1);
   console.log(`Wrote ${kb}KiB to ${outputPng}`);
-} 
+}

--- a/scripts/sprites.ts
+++ b/scripts/sprites.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { glob } from "glob";
-import { Sprites } from "@basemaps/sprites";
+import { Sprites, SpriteSheetResult, SvgId } from "@basemaps/sprites";
 import { Command } from "commander";
 
 const program = new Command();
@@ -18,10 +18,10 @@ const opts = program.opts();
 
 await fs.mkdir(opts.output, { recursive: true });
 
-const sprites = await Promise.all(
+const sprites: SvgId[] = await Promise.all(
   (
     await glob(`${opts.icons}/*.svg`)
-  ).map(async (spritePath) => {
+  ).map(async (spritePath: string): Promise<SvgId> => {
     const id = path.parse(spritePath).name;
     const buffer = await fs.readFile(spritePath);
     return { id, buffer };
@@ -30,15 +30,16 @@ const sprites = await Promise.all(
 
 console.log(`Building ${sprites.length} sprites from ${opts.icons}`);
 
-const generated = await Sprites.generate(sprites, [1, 2, 3]);
+const generated: SpriteSheetResult[] = await Sprites.generate(sprites, [1, 2, 3]);
 
 for (const result of generated) {
-  const scaleText = result.pixelRatio === 1 ? "" : `@${result.pixelRatio}x`;
-  const outputPng = `${opts.output}/sprite${scaleText}.png`;
-  const outputJson = `${opts.output}/sprite${scaleText}.json`;
+  const scaleText: string =
+    result.pixelRatio === 1 ? "" : `@${result.pixelRatio}x`;
+  const outputPng: string = `${opts.output}/sprite${scaleText}.png`;
+  const outputJson: string = `${opts.output}/sprite${scaleText}.json`;
 
   await fs.writeFile(outputPng, result.buffer);
   await fs.writeFile(outputJson, JSON.stringify(result.layout, null, 2));
-  const kb = (result.buffer.length / 1024).toFixed(1);
+  const kb: string = (result.buffer.length / 1024).toFixed(1);
   console.log(`Wrote ${kb}KiB to ${outputPng}`);
-}
+} 

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -33,6 +33,12 @@ program
     ).conflicts("allJson")
   )
   .addOption(
+    new Option(
+      "-ss3, --spritesheet-3x-size",
+      "size of 3x sprite sheet"
+    ).conflicts("allJson")
+  )
+  .addOption(
     new Option("-sh, --shield-json-size", "size of ShieldJSON").conflicts(
       "allJson"
     )
@@ -82,8 +88,8 @@ if (opts.layerCount) {
   process.exit();
 }
 
-function spriteSheetSize(distDir, single) {
-  let size = single ? "" : "@2x";
+function spriteSheetSize(distDir, scale) {
+  let size = scale === 1 ? "" : `@${scale}x`;
   return (
     fs.statSync(`${distDir}/sprites/sprite${size}.png`).size +
     fs.statSync(`${distDir}/sprites/sprite${size}.json`).size
@@ -98,15 +104,21 @@ function gzipSize(content) {
   return zlib.gzipSync(content).length;
 }
 
-const spriteSheet1xSize = spriteSheetSize(distDir, true);
+const spriteSheet1xSize = spriteSheetSize(distDir, 1);
 if (opts.spritesheet1xSize) {
   console.log(spriteSheet1xSize);
   process.exit();
 }
 
-const spriteSheet2xSize = spriteSheetSize(distDir, false);
+const spriteSheet2xSize = spriteSheetSize(distDir, 2);
 if (opts.spritesheet2xSize) {
   console.log(spriteSheet2xSize);
+  process.exit();
+}
+
+const spriteSheet3xSize = spriteSheetSize(distDir, 3);
+if (opts.spritesheet3xSize) {
+  console.log(spriteSheet3xSize);
   process.exit();
 }
 
@@ -146,6 +158,7 @@ const stats = {
   layerGroup: {},
   spriteSheet1xSize,
   spriteSheet2xSize,
+  spriteSheet3xSize,
   shieldJSONSize,
   gzipShieldJSONSize,
 };


### PR DESCRIPTION
Add sprite sheets for 3x pixel ratios, which is needed for newer iPhones.

- I believe this is not yet supported by maplibre, so this is really just getting ahead of that presumed eventual support
- Converts the sprite generation script to typescript
- Updates CI