### PR TITLE
Update Wikidata query for legend labels

### DIFF
--- a/src/js/legend_control.js
+++ b/src/js/legend_control.js
@@ -806,8 +806,8 @@ export default class LegendControl {
         "?network wdt:P361 wd:Q115856945; p:P528 [ ps:P528 ?value; pq:P972 wd:Q110613756 ]";
     } else {
       triple = "?network wdt:P1282 ?tag";
-      filter = `FILTER(REGEX(?tag, "^Tag:network="))`;
-      bind = "BIND(SUBSTR(?tag, 13) AS ?value)";
+      filter = `FILTER(REGEX(?tag, "^network="))`;
+      bind = "BIND(SUBSTR(?tag, 9) AS ?value)";
     }
     return `
 SELECT ?value ?network ?networkLabel WHERE {


### PR DESCRIPTION
Fixed the labels in the “Route markers” section of the legend.

[On September 17](https://www.wikidata.org/wiki/Wikidata:Property_proposal/OpenStreetMap_relation_type), Wikidata split their [OpenStreetMap key or tag <small>(P1282)</small>](https://www.wikidata.org/wiki/Property:P1282) property into [OpenStreetMap tag <small>(P1282)</small>](https://www.wikidata.org/wiki/Property:P1282) and [OpenStreetMap key <small>(P13786)</small>](https://www.wikidata.org/wiki/Property:P13786) properties. P1282 no longer takes a Tag: prefix. The SPARQL query was explicitly filtering on that prefix to weed out keys, but that’s no longer correct. [The updated query](https://w.wiki/FQSx) returns 539 results.