### PR TITLE
Show maritime international boundaries separating two countries

### DIFF
--- a/src/layer/boundary.js
+++ b/src/layer/boundary.js
@@ -206,6 +206,13 @@ export const state = {
   "source-layer": "boundary",
 };
 
+// adm0_* properties are only available on international borders.
+const maritime = [
+  "any",
+  ["==", ["get", "maritime"], 0],
+  ["all", ["has", "adm0_l"], ["has", "adm0_r"]],
+];
+
 export const countryCasing = {
   id: "boundary_country_casing",
   type: "line",
@@ -283,7 +290,7 @@ export const country = {
     "all",
     ["==", ["get", "admin_level"], 2],
     ["==", ["get", "disputed"], 0],
-    ["==", ["get", "maritime"], 0],
+    [...maritime],
   ],
   maxzoom: 24,
   layout: {
@@ -344,7 +351,7 @@ export const countryLabelLeft = {
     "text-letter-spacing": 0.1,
     "text-ignore-placement": true,
   },
-  filter: ["==", ["get", "maritime"], 0],
+  filter: [...maritime],
   maxzoom: 24,
   source: "openmaptiles",
   "source-layer": "boundary",


### PR DESCRIPTION
In #35, we chose not to render maritime boundaries with the rationale that they add noise without providing enough information relevant to a layperson. However, maps and globes customarily make an exception for maritime international boundaries that separate two countries. Otherwise, there are too many situations where islands are implied to belong to the nearest mainland country even if it belongs to some other country. While this can happen at the state or county level too, incorrectly portraying an island as part of one state instead of another is generally less contentious.

This PR adjusts the filters for country borderlines and labels to appear when OpenMapTiles flags the boundary as maritime and acknowledges no fewer than two country codes along it. Unfortunately, OMT only includes maritime boundaries from zoom level 4 and only includes country codes from zoom level 5, so the added borderlines come in perhaps a little later than expected. Short borderlines also appear somewhat inexplicably in various places where a layperson might not expect them, where maritime boundaries touch but not because of any nearby islands. I think this is outweighed by the added clarity in cases where it does matter.

Before | After
----|----
[<img width="801" height="600" alt="West Indies" src="https://github.com/user-attachments/assets/c1cfee1f-31b9-4f46-b5a7-e8a95df9d623" />](https://americanamap.org/#map=7/13.38/-60.796&language=en) | [<img width="800" height="600" alt="West Indies" src="https://github.com/user-attachments/assets/15841c01-0a59-4177-9b68-81a19cc2a544" />](https://preview.ourmap.us/pr/1275/#map=7/13.38/-60.796&language=en)
[<img width="801" height="601" alt="Río de la Plata" src="https://github.com/user-attachments/assets/4f286859-f5eb-49ef-a6d3-df6a358fa749" />](https://americanamap.org/#map=6/-35.116/-56.458&language=en) | [<img width="800" height="600" alt="Río de la Plata" src="https://github.com/user-attachments/assets/b83f7198-c8c4-48fe-8e92-9cb68e1b7f36" />](https://preview.ourmap.us/pr/1275/#map=6/-35.116/-56.458&language=en)
[<img width="800" height="600" alt="Strait of Gibraltar" src="https://github.com/user-attachments/assets/8d356799-a31d-41df-8ae1-56dbc2d9f860" />](https://americanamap.org/#map=9/36.0322/-5.5555&language=en) | [<img width="801" height="600" alt="Strait of Gibraltar" src="https://github.com/user-attachments/assets/cc644bc4-5c72-4826-84a9-1487a7b33c7c" />](https://preview.ourmap.us/pr/1275/#map=9/36.0322/-5.5555&language=en)
[<img width="800" height="600" alt="Aegean Sea" src="https://github.com/user-attachments/assets/617ba67b-6331-433c-88a0-aec9065f3ea2" />](https://americanamap.org/#map=7/37.182/27.453&language=en) | [<img width="800" height="600" alt="Aegean Sea" src="https://github.com/user-attachments/assets/ee3d60a3-2812-47b8-ad35-478ff74f7442" />](https://preview.ourmap.us/pr/1275/#map=7/37.182/27.453&language=en)
[<img width="1602" height="1202" alt="Gulf of Guinea" src="https://github.com/user-attachments/assets/7acb6e16-c5f6-4617-9f06-03a874e0c1b0" />](https://americanamap.org/#map=7/3.003/9.707&language=en) | [<img width="1600" height="1202" alt="Gulf of Guinea" src="https://github.com/user-attachments/assets/617831fd-d807-40c3-93f6-4d2771427e6e" />](https://preview.ourmap.us/pr/1275/#map=7/3.003/9.707&language=en)
[<img width="800" height="601" alt="Phú Quốc" src="https://github.com/user-attachments/assets/a6296e95-42e9-4452-9b19-1a6124875c6b" />](https://americanamap.org/#map=7/10.135/103.963&language=en) | [<img width="800" height="600" alt="Phú Quốc" src="https://github.com/user-attachments/assets/41345f7a-d405-4aa8-955c-4ca78fec5003" />](https://preview.ourmap.us/pr/1275/#map=7/10.135/103.963&language=en)
[<img width="801" height="600" alt="South China Sea" src="https://github.com/user-attachments/assets/11d9810e-cece-4fc9-989a-b861b902b9b7" />](https://americanamap.org/#map=6/9.976/115.815&language=en) | [<img width="800" height="600" alt="South China Sea" src="https://github.com/user-attachments/assets/608084cb-5ab4-4dcf-9401-62eae675abc5" />](https://preview.ourmap.us/pr/1275/#map=6/9.976/115.815&language=en)
[<img width="801" height="600" alt="Daedong Bay" src="https://github.com/user-attachments/assets/4e4a5ab9-ced1-46f3-9454-132ed496c597" />](https://americanamap.org/#map=7/37.844/125.846&language=en) | [<img width="800" height="600" alt="Daedong Bay" src="https://github.com/user-attachments/assets/f2c2ccf7-e8f3-4d4e-bf20-1e9b1075dba3" />](https://preview.ourmap.us/pr/1275/#map=7/37.844/125.846&language=en)
[<img width="800" height="600" alt="Torres Strait" src="https://github.com/user-attachments/assets/e7102557-a011-48e3-882a-d61382fd37f7" />](https://americanamap.org/#map=7/-9.308/142.234&language=en) | [<img width="801" height="600" alt="Torres Strait" src="https://github.com/user-attachments/assets/4010b391-e75a-4cfc-b520-69b650bc8b95" />](https://preview.ourmap.us/pr/1275/#map=7/-9.308/142.234&language=en)

Previous discussion [in Slack](https://osmus.slack.com/archives/C01V02K52UX/p1626114683305000) and some prior art [in Street Spirit](https://en.osm.town/@pnorman/109384107262889222).