### PR TITLE
Fix object_compare handling of added layer groups

### DIFF
--- a/scripts/object_compare.ts
+++ b/scripts/object_compare.ts
@@ -52,7 +52,10 @@ export function calculateDifference<T extends Record<string, any>>(
     if (!(key in object1!)) {
       if (typeof object2![key] === "object" && object2![key] !== null) {
         // For nested objects, recursively calculate the difference
-        (difference as any)[key] = calculateDifference(null, object2![key]) as any;
+        (difference as any)[key] = calculateDifference(
+          null,
+          object2![key]
+        ) as any;
       } else {
         (difference as any)[key] = object2![key];
       }

--- a/scripts/object_compare.ts
+++ b/scripts/object_compare.ts
@@ -93,22 +93,22 @@ function negate<T extends object>(object: T): T {
 // "|           | main          | this PR      | change          | % change        |",
 export type ComparedStats = {
   name: string;
-  beforeValue: number | null;
-  afterValue: number | null;
+  beforeValue: number | null | undefined;
+  afterValue: number | null | undefined;
   change: number;
   pctChange: number | null;
 };
 
 export function statsComparisonRow(
   name: string,
-  val1: number | null,
-  val2: number | null,
+  val1: number | null | undefined,
+  val2: number | null | undefined,
   change: number
 ): ComparedStats {
   let pctChange: number | null;
 
-  if (val1 !== null) {
-    if (val2 !== null) {
+  if (val1 !== null && val1 !== undefined) {
+    if (val2 !== null && val2 !== undefined) {
       pctChange = change / val1;
     } else {
       pctChange = -1;
@@ -133,8 +133,8 @@ const pctFormat: Intl.NumberFormatOptions = {
   signDisplay: "exceptZero",
 };
 
-function naLocString(val: number | null) {
-  return val !== null ? val.toLocaleString("en") : "N/A";
+function naLocString(val: number | null | undefined) {
+  return val !== null && val !== undefined ? val.toLocaleString("en") : "N/A";
 }
 
 /**
@@ -154,8 +154,8 @@ export function mdStringValues(stats: ComparedStats): string[] {
 
 export function mdCompareRow(
   name: string,
-  val1: number | null,
-  val2: number | null,
+  val1: number | null | undefined,
+  val2: number | null | undefined,
   change: number
 ): string {
   return mdStringValues(statsComparisonRow(name, val1, val2, change)).join(

--- a/test/stats_compare/stats_compare.spec.ts
+++ b/test/stats_compare/stats_compare.spec.ts
@@ -59,6 +59,18 @@ describe("stats_compare", function () {
         simpleAnullmdRow
       );
     });
+    it("tests md compare with undefined values", function () {
+      // Test that undefined values are handled properly (this was the original bug)
+      expect(mdCompareRow("test", 5, undefined, 5)).to.deep.equal(
+        "test | 5 | N/A | 5 | -100.0%"
+      );
+      expect(mdCompareRow("test", undefined, 5, 5)).to.deep.equal(
+        "test | N/A | 5 | 5 | N/A"
+      );
+      expect(mdCompareRow("test", undefined, undefined, 0)).to.deep.equal(
+        "test | N/A | N/A | 0 | N/A"
+      );
+    });
   });
 
   describe("#calculateDifference with JSON test cases", function () {

--- a/test/stats_compare/stats_compare.spec.ts
+++ b/test/stats_compare/stats_compare.spec.ts
@@ -3,6 +3,8 @@ import {
   mdCompareRow,
 } from "../../scripts/object_compare";
 import { expect } from "chai";
+import * as fs from "fs";
+import * as path from "path";
 
 const a = 3;
 const b = 4;
@@ -56,6 +58,90 @@ describe("stats_compare", function () {
       expect(mdCompareRow("a", simpleA.a, null, negSimpleA.a)).to.deep.equal(
         simpleAnullmdRow
       );
+    });
+  });
+
+  describe("#calculateDifference with JSON test cases", function () {
+    interface Stats {
+      layerCount: number;
+      styleSize: number;
+      gzipStyleSize: number;
+      shieldJSONSize: number;
+      gzipShieldJSONSize: number;
+      spriteSheet1xSize: number;
+      spriteSheet2xSize: number;
+      layerGroup: {
+        [key: string]: {
+          layerCount: number;
+          size: number;
+        };
+      };
+    }
+
+    function loadStats(filename: string): Stats {
+      const filePath = path.join(path.dirname(new URL(import.meta.url).pathname), "test-cases", filename);
+      const content = fs.readFileSync(filePath, "utf8");
+      return JSON.parse(content);
+    }
+
+    it("tests layer group added", function () {
+      const baseStats = loadStats("base_stats.json");
+      const addedStats = loadStats("layer_group_added.json");
+      const difference = calculateDifference(baseStats, addedStats);
+
+      // Check that urbanareas was added
+      expect(difference.layerGroup.urbanareas).to.deep.equal({
+        size: 18183,
+        layerCount: 3
+      });
+
+      // Check that place was modified
+      expect(difference.layerGroup.place).to.deep.equal({
+        size: -18113, // 21701 - 39814
+        layerCount: -3  // 9 - 12
+      });
+
+      // Check overall stats changes
+      expect(difference.layerCount).to.equal(3); // 350 - 347
+      expect(difference.styleSize).to.equal(70); // 1122329 - 1122259
+    });
+
+    it("tests layer group removed", function () {
+      const baseStats = loadStats("base_stats.json");
+      const removedStats = loadStats("layer_group_removed.json");
+      const difference = calculateDifference(baseStats, removedStats);
+
+      // Check that place was removed (negated)
+      expect(difference.layerGroup.place).to.deep.equal({
+        size: -39814, // -39814
+        layerCount: -12  // -12
+      });
+
+      // Check overall stats changes
+      expect(difference.layerCount).to.equal(-12); // 335 - 347
+      expect(difference.styleSize).to.equal(-7259); // 1115000 - 1122259
+    });
+
+    it("tests mixed changes (removed and added)", function () {
+      const removedStats = loadStats("layer_group_removed.json");
+      const addedStats = loadStats("layer_group_added.json");
+      const difference = calculateDifference(removedStats, addedStats);
+
+      // Check that place was added back (since it was removed in removedStats)
+      expect(difference.layerGroup.place).to.deep.equal({
+        size: 21701, // Just the new value since it was missing in removedStats
+        layerCount: 9  // Just the new value since it was missing in removedStats
+      });
+
+      // Check that urbanareas was added
+      expect(difference.layerGroup.urbanareas).to.deep.equal({
+        size: 18183,
+        layerCount: 3
+      });
+
+      // Check overall stats changes
+      expect(difference.layerCount).to.equal(15); // 350 - 335
+      expect(difference.styleSize).to.equal(7329); // 1122329 - 1115000
     });
   });
 });

--- a/test/stats_compare/stats_compare.spec.ts
+++ b/test/stats_compare/stats_compare.spec.ts
@@ -79,7 +79,11 @@ describe("stats_compare", function () {
     }
 
     function loadStats(filename: string): Stats {
-      const filePath = path.join(path.dirname(new URL(import.meta.url).pathname), "test-cases", filename);
+      const filePath = path.join(
+        path.dirname(new URL(import.meta.url).pathname),
+        "test-cases",
+        filename
+      );
       const content = fs.readFileSync(filePath, "utf8");
       return JSON.parse(content);
     }
@@ -92,13 +96,13 @@ describe("stats_compare", function () {
       // Check that urbanareas was added
       expect(difference.layerGroup.urbanareas).to.deep.equal({
         size: 18183,
-        layerCount: 3
+        layerCount: 3,
       });
 
       // Check that place was modified
       expect(difference.layerGroup.place).to.deep.equal({
         size: -18113, // 21701 - 39814
-        layerCount: -3  // 9 - 12
+        layerCount: -3, // 9 - 12
       });
 
       // Check overall stats changes
@@ -114,7 +118,7 @@ describe("stats_compare", function () {
       // Check that place was removed (negated)
       expect(difference.layerGroup.place).to.deep.equal({
         size: -39814, // -39814
-        layerCount: -12  // -12
+        layerCount: -12, // -12
       });
 
       // Check overall stats changes
@@ -130,13 +134,13 @@ describe("stats_compare", function () {
       // Check that place was added back (since it was removed in removedStats)
       expect(difference.layerGroup.place).to.deep.equal({
         size: 21701, // Just the new value since it was missing in removedStats
-        layerCount: 9  // Just the new value since it was missing in removedStats
+        layerCount: 9, // Just the new value since it was missing in removedStats
       });
 
       // Check that urbanareas was added
       expect(difference.layerGroup.urbanareas).to.deep.equal({
         size: 18183,
-        layerCount: 3
+        layerCount: 3,
       });
 
       // Check overall stats changes

--- a/test/stats_compare/test-cases/base_stats.json
+++ b/test/stats_compare/test-cases/base_stats.json
@@ -1,0 +1,75 @@
+{
+    "layerCount": 347,
+    "styleSize": 1122259,
+    "gzipStyleSize": 35118,
+    "layerGroup": {
+      "background": {
+        "size": 122,
+        "layerCount": 1
+      },
+      "landuse": {
+        "size": 309,
+        "layerCount": 1
+      },
+      "park": {
+        "size": 2517,
+        "layerCount": 3
+      },
+      "aeroway": {
+        "size": 2059,
+        "layerCount": 7
+      },
+      "landcover": {
+        "size": 361,
+        "layerCount": 2
+      },
+      "boundary": {
+        "size": 14392,
+        "layerCount": 11
+      },
+      "dem": {
+        "size": 271,
+        "layerCount": 1
+      },
+      "water": {
+        "size": 912,
+        "layerCount": 3
+      },
+      "waterway": {
+        "size": 3543,
+        "layerCount": 3
+      },
+      "transportation": {
+        "size": 1024566,
+        "layerCount": 291
+      },
+      "building": {
+        "size": 292,
+        "layerCount": 1
+      },
+      "transportation_name": {
+        "size": 9740,
+        "layerCount": 3
+      },
+      "poi": {
+        "size": 12415,
+        "layerCount": 2
+      },
+      "water_name": {
+        "size": 4647,
+        "layerCount": 2
+      },
+      "aerodrome_label": {
+        "size": 5951,
+        "layerCount": 4
+      },
+      "place": {
+        "size": 39814,
+        "layerCount": 12
+      }
+    },
+    "spriteSheet1xSize": 124089,
+    "spriteSheet2xSize": 248190,
+    "shieldJSONSize": 462657,
+    "gzipShieldJSONSize": 19144
+  }

--- a/test/stats_compare/test-cases/base_stats.json
+++ b/test/stats_compare/test-cases/base_stats.json
@@ -1,75 +1,75 @@
 {
-    "layerCount": 347,
-    "styleSize": 1122259,
-    "gzipStyleSize": 35118,
-    "layerGroup": {
-      "background": {
-        "size": 122,
-        "layerCount": 1
-      },
-      "landuse": {
-        "size": 309,
-        "layerCount": 1
-      },
-      "park": {
-        "size": 2517,
-        "layerCount": 3
-      },
-      "aeroway": {
-        "size": 2059,
-        "layerCount": 7
-      },
-      "landcover": {
-        "size": 361,
-        "layerCount": 2
-      },
-      "boundary": {
-        "size": 14392,
-        "layerCount": 11
-      },
-      "dem": {
-        "size": 271,
-        "layerCount": 1
-      },
-      "water": {
-        "size": 912,
-        "layerCount": 3
-      },
-      "waterway": {
-        "size": 3543,
-        "layerCount": 3
-      },
-      "transportation": {
-        "size": 1024566,
-        "layerCount": 291
-      },
-      "building": {
-        "size": 292,
-        "layerCount": 1
-      },
-      "transportation_name": {
-        "size": 9740,
-        "layerCount": 3
-      },
-      "poi": {
-        "size": 12415,
-        "layerCount": 2
-      },
-      "water_name": {
-        "size": 4647,
-        "layerCount": 2
-      },
-      "aerodrome_label": {
-        "size": 5951,
-        "layerCount": 4
-      },
-      "place": {
-        "size": 39814,
-        "layerCount": 12
-      }
+  "layerCount": 347,
+  "styleSize": 1122259,
+  "gzipStyleSize": 35118,
+  "layerGroup": {
+    "background": {
+      "size": 122,
+      "layerCount": 1
     },
-    "spriteSheet1xSize": 124089,
-    "spriteSheet2xSize": 248190,
-    "shieldJSONSize": 462657,
-    "gzipShieldJSONSize": 19144
-  }
+    "landuse": {
+      "size": 309,
+      "layerCount": 1
+    },
+    "park": {
+      "size": 2517,
+      "layerCount": 3
+    },
+    "aeroway": {
+      "size": 2059,
+      "layerCount": 7
+    },
+    "landcover": {
+      "size": 361,
+      "layerCount": 2
+    },
+    "boundary": {
+      "size": 14392,
+      "layerCount": 11
+    },
+    "dem": {
+      "size": 271,
+      "layerCount": 1
+    },
+    "water": {
+      "size": 912,
+      "layerCount": 3
+    },
+    "waterway": {
+      "size": 3543,
+      "layerCount": 3
+    },
+    "transportation": {
+      "size": 1024566,
+      "layerCount": 291
+    },
+    "building": {
+      "size": 292,
+      "layerCount": 1
+    },
+    "transportation_name": {
+      "size": 9740,
+      "layerCount": 3
+    },
+    "poi": {
+      "size": 12415,
+      "layerCount": 2
+    },
+    "water_name": {
+      "size": 4647,
+      "layerCount": 2
+    },
+    "aerodrome_label": {
+      "size": 5951,
+      "layerCount": 4
+    },
+    "place": {
+      "size": 39814,
+      "layerCount": 12
+    }
+  },
+  "spriteSheet1xSize": 124089,
+  "spriteSheet2xSize": 248190,
+  "shieldJSONSize": 462657,
+  "gzipShieldJSONSize": 19144
+}

--- a/test/stats_compare/test-cases/layer_group_added.json
+++ b/test/stats_compare/test-cases/layer_group_added.json
@@ -1,0 +1,79 @@
+{
+    "layerCount": 350,
+    "styleSize": 1122329,
+    "gzipStyleSize": 35206,
+    "layerGroup": {
+      "background": {
+        "size": 122,
+        "layerCount": 1
+      },
+      "landuse": {
+        "size": 309,
+        "layerCount": 1
+      },
+      "park": {
+        "size": 2517,
+        "layerCount": 3
+      },
+      "aeroway": {
+        "size": 2059,
+        "layerCount": 7
+      },
+      "landcover": {
+        "size": 361,
+        "layerCount": 2
+      },
+      "boundary": {
+        "size": 14392,
+        "layerCount": 11
+      },
+      "dem": {
+        "size": 271,
+        "layerCount": 1
+      },
+      "water": {
+        "size": 912,
+        "layerCount": 3
+      },
+      "waterway": {
+        "size": 3543,
+        "layerCount": 3
+      },
+      "transportation": {
+        "size": 1024566,
+        "layerCount": 291
+      },
+      "building": {
+        "size": 292,
+        "layerCount": 1
+      },
+      "transportation_name": {
+        "size": 9740,
+        "layerCount": 3
+      },
+      "poi": {
+        "size": 12415,
+        "layerCount": 2
+      },
+      "water_name": {
+        "size": 4647,
+        "layerCount": 2
+      },
+      "aerodrome_label": {
+        "size": 5951,
+        "layerCount": 4
+      },
+      "place": {
+        "size": 21701,
+        "layerCount": 9
+      },
+      "urbanareas": {
+        "size": 18183,
+        "layerCount": 3
+      }
+    },
+    "spriteSheet1xSize": 124089,
+    "spriteSheet2xSize": 248190,
+    "shieldJSONSize": 462657,
+    "gzipShieldJSONSize": 19144
+  }

--- a/test/stats_compare/test-cases/layer_group_added.json
+++ b/test/stats_compare/test-cases/layer_group_added.json
@@ -1,79 +1,79 @@
 {
-    "layerCount": 350,
-    "styleSize": 1122329,
-    "gzipStyleSize": 35206,
-    "layerGroup": {
-      "background": {
-        "size": 122,
-        "layerCount": 1
-      },
-      "landuse": {
-        "size": 309,
-        "layerCount": 1
-      },
-      "park": {
-        "size": 2517,
-        "layerCount": 3
-      },
-      "aeroway": {
-        "size": 2059,
-        "layerCount": 7
-      },
-      "landcover": {
-        "size": 361,
-        "layerCount": 2
-      },
-      "boundary": {
-        "size": 14392,
-        "layerCount": 11
-      },
-      "dem": {
-        "size": 271,
-        "layerCount": 1
-      },
-      "water": {
-        "size": 912,
-        "layerCount": 3
-      },
-      "waterway": {
-        "size": 3543,
-        "layerCount": 3
-      },
-      "transportation": {
-        "size": 1024566,
-        "layerCount": 291
-      },
-      "building": {
-        "size": 292,
-        "layerCount": 1
-      },
-      "transportation_name": {
-        "size": 9740,
-        "layerCount": 3
-      },
-      "poi": {
-        "size": 12415,
-        "layerCount": 2
-      },
-      "water_name": {
-        "size": 4647,
-        "layerCount": 2
-      },
-      "aerodrome_label": {
-        "size": 5951,
-        "layerCount": 4
-      },
-      "place": {
-        "size": 21701,
-        "layerCount": 9
-      },
-      "urbanareas": {
-        "size": 18183,
-        "layerCount": 3
-      }
+  "layerCount": 350,
+  "styleSize": 1122329,
+  "gzipStyleSize": 35206,
+  "layerGroup": {
+    "background": {
+      "size": 122,
+      "layerCount": 1
     },
-    "spriteSheet1xSize": 124089,
-    "spriteSheet2xSize": 248190,
-    "shieldJSONSize": 462657,
-    "gzipShieldJSONSize": 19144
-  }
+    "landuse": {
+      "size": 309,
+      "layerCount": 1
+    },
+    "park": {
+      "size": 2517,
+      "layerCount": 3
+    },
+    "aeroway": {
+      "size": 2059,
+      "layerCount": 7
+    },
+    "landcover": {
+      "size": 361,
+      "layerCount": 2
+    },
+    "boundary": {
+      "size": 14392,
+      "layerCount": 11
+    },
+    "dem": {
+      "size": 271,
+      "layerCount": 1
+    },
+    "water": {
+      "size": 912,
+      "layerCount": 3
+    },
+    "waterway": {
+      "size": 3543,
+      "layerCount": 3
+    },
+    "transportation": {
+      "size": 1024566,
+      "layerCount": 291
+    },
+    "building": {
+      "size": 292,
+      "layerCount": 1
+    },
+    "transportation_name": {
+      "size": 9740,
+      "layerCount": 3
+    },
+    "poi": {
+      "size": 12415,
+      "layerCount": 2
+    },
+    "water_name": {
+      "size": 4647,
+      "layerCount": 2
+    },
+    "aerodrome_label": {
+      "size": 5951,
+      "layerCount": 4
+    },
+    "place": {
+      "size": 21701,
+      "layerCount": 9
+    },
+    "urbanareas": {
+      "size": 18183,
+      "layerCount": 3
+    }
+  },
+  "spriteSheet1xSize": 124089,
+  "spriteSheet2xSize": 248190,
+  "shieldJSONSize": 462657,
+  "gzipShieldJSONSize": 19144
+}

--- a/test/stats_compare/test-cases/layer_group_removed.json
+++ b/test/stats_compare/test-cases/layer_group_removed.json
@@ -1,0 +1,71 @@
+{
+  "layerCount": 335,
+  "styleSize": 1115000,
+  "gzipStyleSize": 34000,
+  "layerGroup": {
+    "background": {
+      "size": 122,
+      "layerCount": 1
+    },
+    "landuse": {
+      "size": 309,
+      "layerCount": 1
+    },
+    "park": {
+      "size": 2517,
+      "layerCount": 3
+    },
+    "aeroway": {
+      "size": 2059,
+      "layerCount": 7
+    },
+    "landcover": {
+      "size": 361,
+      "layerCount": 2
+    },
+    "boundary": {
+      "size": 14392,
+      "layerCount": 11
+    },
+    "dem": {
+      "size": 271,
+      "layerCount": 1
+    },
+    "water": {
+      "size": 912,
+      "layerCount": 3
+    },
+    "waterway": {
+      "size": 3543,
+      "layerCount": 3
+    },
+    "transportation": {
+      "size": 1024566,
+      "layerCount": 291
+    },
+    "building": {
+      "size": 292,
+      "layerCount": 1
+    },
+    "transportation_name": {
+      "size": 9740,
+      "layerCount": 3
+    },
+    "poi": {
+      "size": 12415,
+      "layerCount": 2
+    },
+    "water_name": {
+      "size": 4647,
+      "layerCount": 2
+    },
+    "aerodrome_label": {
+      "size": 5951,
+      "layerCount": 4
+    }
+  },
+  "spriteSheet1xSize": 124089,
+  "spriteSheet2xSize": 248190,
+  "shieldJSONSize": 462657,
+  "gzipShieldJSONSize": 19144
+}


### PR DESCRIPTION
As we discovered in #1276, `object_compare.ts` fails when a new layer group is added to the style. This fixes that script and adds test cases to verify that `object_compare` is working properly.

Note: the `object_compare` script, is used by GitHub actions to produce a report in the checks tab showing stats on layer sizes and what was added/removed from the style.