### PR TITLE
Change prefixes on Poland networks to uppercase

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -4189,7 +4189,7 @@ export function loadShields() {
   };
 
   // Poland
-  shields["pl:expressway"] = shields["pl:motorway"] = roundedRectShield(
+  shields["PL:expressway"] = shields["PL:motorway"] = roundedRectShield(
     Color.shields.red,
     Color.shields.white,
     Color.shields.white,


### PR DESCRIPTION
Poland is now using `PL:expressway` and `PL:motorway` network values rather than lowercase versions.  `pl:national` appears to still be the standard in use for that network.

This PR changes the expressway/motorway network names.