### PR TITLE
Replace GitHub ribbon with pure CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "color-rgba": "^2.4.0",
         "events": "^3.3.0",
         "fonteditor-core": "^2.1.11",
+        "github-fork-ribbon-css": "^0.2.3",
         "openmapsamples": "github:adamfranco/OpenMapSamples",
         "openmapsamples-maplibre": "github:adamfranco/OpenMapSamples-MapLibre",
         "tokenfield": "^1.5.2"
@@ -2630,6 +2631,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-fork-ribbon-css": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/github-fork-ribbon-css/-/github-fork-ribbon-css-0.2.3.tgz",
+      "integrity": "sha512-cmGBV4sivRwmnteSOkqMjN2cnP5/J1SU5aDCVYsBWHmDokZ/JjwGEkduCxY9IULHdCPpw1WSk5Cy8N1LF6jOEw==",
+      "license": "MIT"
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "color-rgba": "^2.4.0",
     "events": "^3.3.0",
     "fonteditor-core": "^2.1.11",
+    "github-fork-ribbon-css": "^0.2.3",
     "openmapsamples": "github:adamfranco/OpenMapSamples",
     "openmapsamples-maplibre": "github:adamfranco/OpenMapSamples-MapLibre",
     "tokenfield": "^1.5.2"

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -33,6 +33,10 @@ const buildWith = async (
       "fonts.css",
     ].map((f) => copyFile(`src/${f}`, `dist/${f}`))
   );
+  await copyFile(
+    "node_modules/github-fork-ribbon-css/gh-fork-ribbon.css",
+    "dist/gh-fork-ribbon.css"
+  );
 
   const localConfig = await maybeLocalConfig();
 

--- a/src/index.html
+++ b/src/index.html
@@ -91,6 +91,12 @@
     </style>
     <script type="module" src="americana.js"></script>
     <link rel="stylesheet" href="americana.css" />
+    <link rel="stylesheet" href="gh-fork-ribbon.css" />
+    <style>
+      .github-fork-ribbon::before {
+        background-color: #006747;
+      }
+    </style>
     <link
       rel="stylesheet"
       href="https://kanecohen.github.io/tokenfield/css/tokenfield.css"
@@ -100,22 +106,13 @@
   <body>
     <div id="map"></div>
     <div id="attribution-logo"></div>
-    <a href="https://github.com/osm-americana/openstreetmap-americana/"
-      ><img
-        loading="lazy"
-        width="149"
-        height="149"
-        src="https://github.blog/wp-content/uploads/2008/12/forkme_right_green_007200.png?resize=149%2C149"
-        alt="Fork me on GitHub"
-        style="
-          position: absolute;
-          top: 0;
-          right: 0;
-          border: 0;
-          z-index: 100;
-          clip-path: polygon(0% 0%, 100% 0%, 100% 100%);
-        "
-    /></a>
+    <a
+      class="github-fork-ribbon right-top"
+      href="https://github.com/osm-americana/openstreetmap-americana/"
+      data-ribbon="Fork me on GitHub"
+      title="OpenStreetMap Americana is dedicated to the public domain. You can freely adapt it for any purpose. To get started, visit our repository on GitHub."
+      >Fork me on GitHub</a
+    >
     <template id="legend">
       <h2>Legend</h2>
       <div id="legend-container"></div>


### PR DESCRIPTION
Replaced the “Fork me on GitHub” ribbon with [a pure CSS implementation](https://simonwhitaker.github.io/github-fork-ribbon-css/) via NPM. The new implementation looks sharper on high-resolution displays, no longer takes over the corner of the page beyond the dogear for hit-testing purposes, and can be localized more easily (#744). The NPM package colors the ribbon a deluxe red by default, but I changed it to MUTCD green.[^mutcd]

Before | After
----|----
[<img width="400" height="300" alt="Fuzzy" src="https://github.com/user-attachments/assets/6b26baec-7a9c-4749-9e63-ded4563abc78" />](https://americanamap.org/#map=4/40.5/-94) | [<img width="400" height="300" alt="Sharp" src="https://github.com/user-attachments/assets/3c443bf8-6fbf-4f66-94ce-0c257dba905b" />](https://preview.americanamap.org/pr/1303/#map=4/40.5/-94)

Fixes #1295.

[^mutcd]: The color of guide signs about forks in the road. 🥁