### PR TITLE
Accept language subtags without crashing

### DIFF
--- a/src/constants/label.js
+++ b/src/constants/label.js
@@ -23,9 +23,17 @@ export function getLocales() {
     let components = locale.split("-");
     while (components.length > 0) {
       let parent = components.join("-");
-      if (!localeSet.has(parent)) locales.push(parent);
-      localeSet.add(parent);
+      try {
+        // Preflight the parent locale in case it’s incomplete like `en-x`.
+        new Intl.Locale(parent);
+        if (!localeSet.has(parent)) locales.push(parent);
+        localeSet.add(parent);
+      } catch {}
       components.pop();
+      // A Unicode extension like -u-nu must be followed by another subtag.
+      if (components.at(-1)?.length === 2 && components.at(-2) === "u") {
+        components.pop();
+      }
     }
   }
   return locales;

--- a/src/js/language_label.js
+++ b/src/js/language_label.js
@@ -199,7 +199,13 @@ export var label = new LanguageControl();
 export function displayLocales(locales) {
   let languageNames = new Intl.DisplayNames(locales, { type: "language" });
   let listFormat = new Intl.ListFormat(locales, { type: "disjunction" });
-  document.getElementById("language-field").textContent = listFormat.format(
-    locales.map((locale) => languageNames.of(locale))
-  );
+  let formattedNames = locales.map((locale) => {
+    try {
+      return languageNames.of(locale);
+    } catch {
+      return locale;
+    }
+  });
+  document.getElementById("language-field").textContent =
+    listFormat.format(formattedNames);
 }

--- a/test/spec/label.js
+++ b/test/spec/label.js
@@ -92,6 +92,20 @@ describe("label", function () {
         "http://localhost:1776/#map=1/2/3&language=tlh-UN,ase"
       );
       expect(Label.getLocales()).to.eql(["tlh-UN", "tlh", "ase"]);
+      window.location = new URL(
+        "http://localhost:1776/#map=1/2/3&language=en-t-zh,zh-u-nu-hant,en-u-sd-usnc,es-fonipa,fr-x-gallo"
+      );
+      expect(Label.getLocales()).to.eql([
+        "en-t-zh",
+        "en",
+        "zh-u-nu-hant",
+        "zh",
+        "en-u-sd-usnc",
+        "es-fonipa",
+        "es",
+        "fr-x-gallo",
+        "fr",
+      ]);
     });
   });
 


### PR DESCRIPTION
Ignore nonsensical partial locales derived from the user’s requested locale. Recover from errors generating localized names of locales for the language picker control.

https://preview.americanamap.org/pr/1305/#map=11/36.5591/-78.5094&language=en-t-zh,zh-u-nu-hant,en-u-sd-usnc,es-fonipa,fr-x-gallo

Fixes #1304.