### PR TITLE
Upgrade macOS 13 runner to macOS 15

### DIFF
--- a/.github/workflows/test-build-macos-15.yml
+++ b/.github/workflows/test-build-macos-15.yml
@@ -1,4 +1,4 @@
-name: Test Build (MacOS 15)
+name: Test Build (macOS 15)
 
 on:
   pull_request:


### PR DESCRIPTION
Builds have begun [failing](https://github.com/osm-americana/openstreetmap-americana/actions/runs/20110735560?pr=1312) because the macOS 13 runner has been retired: actions/runner-images#13046. This upgrades the runner to macOS 15.