### PR TITLE
add signed shields in KR

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3727,7 +3727,7 @@ export function loadShields() {
     Color.shields.yellow,
     Color.shields.white,
     Color.shields.blue,
-    35,
+    30,
     0
   );
 


### PR DESCRIPTION
Added county road shields in Korea. Because they have no legally designated road shields, we can only add shields which are found at road signs.

- KR:41:Gapyeong
![IMG_9430](https://github.com/user-attachments/assets/50248f02-81e2-4d13-885d-dd476db1b706)

- KR:42:Hongcheon
<img width="1179" height="854" alt="image" src="https://github.com/user-attachments/assets/184015b6-c62d-4130-b18e-5a517db5d4d2" />

- KR:45:Wanju
<img width="1179" height="918" alt="image" src="https://github.com/user-attachments/assets/3ef3e9b9-4028-4cab-9125-fb5f3ef7e638" />

- KR:45:Gochang
![IMG_9499](https://github.com/user-attachments/assets/acdf1105-4b55-41a6-93bd-3032522c408a)

- KR:48:Namhae
![IMG_9472](https://github.com/user-attachments/assets/6223163c-f417-49af-9ab2-0d2386b8d081)

- KR:27:Gunwi
![output_775079004](https://github.com/user-attachments/assets/d2fab97a-f5c3-4326-b716-c95f0336b37b)

- KR:46:Sinan
![IMG_9507](https://github.com/user-attachments/assets/166aa822-03a7-4d04-b9fd-4531e7af0c3e)
