### PR TITLE
Add local language gloss to village labels

### DIFF
--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -81,7 +81,7 @@ export const village = {
         [11, 0.5],
       ],
     },
-    "text-field": localizedName,
+    "text-field": localizedNameWithLocalGloss,
     "text-anchor": "bottom",
     "text-variable-anchor": [
       "bottom",


### PR DESCRIPTION
Village labels now include a gloss indicating the name in the local language when it differs from the name in the user’s preferred language. This adds some clutter to areas of the map with lots of villages, but it’s more consistent with our city and town labels, making it easier for the user to predict which language the main part of the label is in.

Before | After
----|----
[<img width="800" height="600" alt="Yuanlin City" src="https://github.com/user-attachments/assets/cf713b49-1142-4ac8-8945-806986676cdb" />](https://americanamap.org/#map=11/23.9198/120.5851&language=en-US) | [<img width="800" height="600" alt="Yuanlin City (員林市)" src="https://github.com/user-attachments/assets/f5fbf8b3-f52d-4898-ac80-b6f522e09c03" />](https://preview.americanamap.org/pr/1347/#map=11/23.9198/120.5851&language=en-US)
[<img width="800" height="600" alt="Boonville" src="https://github.com/user-attachments/assets/0b6d1a45-9765-44ef-b45b-b95f9f0942cb" />](https://americanamap.org/#map=12/39.03513/-123.40113&language=en-boont) | [<img width="800" height="600" alt="Boonville (Boont)" src="https://github.com/user-attachments/assets/c08f17f2-00bd-423f-b9b4-1c14fae0a04b" />](https://preview.americanamap.org/pr/1347/#map=12/39.03513/-123.40113&language=en-boont)

In #670, we added a local language gloss to town labels but didn’t go as far as adding it to village labels. Conventional print atlases only gloss major cities, not small towns or villages. But that’s mainly because, when the native name would be in a different writing system, they primarily label the place with a transliteration and gloss any exonym in the current language. Only major cities have anglicizations. We don’t currently have the technical capability to transliterate all the places automatically, so we show the native name verbatim as the gloss.

Another consideration was the size of the generated style JSON, which can impact load time and responsiveness at runtime. In cursory testing, I didn’t notice a significant change in performance. This could be due to performance optimizations in Diplomat since we migrated to it.