### PR TITLE
Make Dependabot widen dependencies for shieldlib

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,19 @@ updates:
   - package-ecosystem: "npm"
     directories:
       - "/"
+    versioning-strategy: increase
+    schedule:
+      interval: "weekly"
+    cooldown:
+      semver-major-days: 90
+      semver-minor-days: 21
+      semver-patch-days: 7
+    labels:
+      - "build"
+  - package-ecosystem: "npm"
+    directories:
       - "shieldlib/"
+    versioning-strategy: widen
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
Tell Dependabot to use a different dependency versioning strategy for the shield library that’s appropriate for libraries.

This is a stopgap until we spin out the shield library as its own repository: #889. It should unblock #1333 and #1338, which incorrectly narrowed the requirements for the shield library, as well as #1334 #1335 #1336 #1339 #1341, which fail to build because of a mismatch between the two package.json files.