### PR TITLE
Shields for Illinois: Cook and Will counties

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1305,6 +1305,7 @@ export function loadShields() {
     "Clay",
     "Clinton",
     "Coles",
+    "Cook",
     "Cumberland",
     "DeKalb",
     "De_Witt",
@@ -1336,6 +1337,7 @@ export function loadShields() {
     "Schuyler",
     "Shelby",
     "Saint_Clair",
+    "Will",
     "Winnebago",
     "Woodford",
   ].forEach(


### PR DESCRIPTION
The two Illinois counties use the standard yellow-blue inverted pentagon.