### PR TITLE
Accept any valid language in the language picker

### DIFF
--- a/src/js/language_control.js
+++ b/src/js/language_control.js
@@ -183,7 +183,11 @@ langChanger.onclick = function () {
     tf = new Tokenfield({
       el: document.querySelector("#language-picker"), // Attach Tokenfield to the input element with class "text-input"
       items: getLanguageNamesByCode(),
-      newItems: false,
+      validateNewItem: (value) => {
+        try {
+          return new Intl.Locale(value);
+        } catch (e) {}
+      },
     });
     document.querySelectorAll(".tokenfield").forEach((e) => {
       Object.assign(e.style, {
@@ -196,7 +200,7 @@ langChanger.onclick = function () {
     tf.on("change", function () {
       let items = tf.getItems();
       let langCodes = [];
-      items.forEach((element) => langCodes.push(element.id));
+      items.forEach((element) => langCodes.push(element.id || element.name));
       let langQuery = langCodes.join(",");
       let hash = window.location.hash.substr(1); // omit #
       let searchParams = new URLSearchParams(hash);


### PR DESCRIPTION
The language picker now accepts any language. The autocompletion menu lists any ISO 639-2 or ISO 639-3 code, plus any other valid IETF language tag that appears at least 20 times in `name:*=*` in OSM, as long as the browser supports it with a display name. But the user can enter any well-formed IETF language tag, even if it isn’t in this list. For example, if you know that `gcf` is the language tag for Guadeloupean Creole French, you can enter `gcf` in the picker.

<img width="316" height="184" alt="English (IPA Phonetics), en-u-sd-usnm, fr-gallo" src="https://github.com/user-attachments/assets/c3324513-bcab-4173-9b93-90b1928207c5" />

<img width="316" height="184" alt="gcf results in gcf-Latn-GP plus three other locales." src="https://github.com/user-attachments/assets/4392ac6b-a4b8-45ba-8ea1-cad04e043d47" />

Fixes #836, fixes #1365.