### PR TITLE
Suggest all known language names

### DIFF
--- a/src/js/language_control.js
+++ b/src/js/language_control.js
@@ -131,6 +131,8 @@ function getLanguageNamesByCode() {
   _languageNamesByCode = Object.entries(languageNamesByCode).map(
     ([id, name]) => ({ id, name })
   );
+  const collator = new Intl.Collator(initialLocales);
+  _languageNamesByCode.sort((a, b) => collator.compare(a.name, b.name));
   return _languageNamesByCode;
 }
 


### PR DESCRIPTION
Fixed an issue where the language picker’s dropdown menu only listed very common languages, even after #1368. The fix is to filter languages by whether the browser has a name for it in the current language, not whether the browser has a name for every language in that language.

<img width="415" height="440" alt="Old English, English, American English, English (IPA Phonetics), Middle English, Jamaican Creole English, Nheengatu" src="https://github.com/user-attachments/assets/18ad5b23-de2c-4bf3-a8bd-9b6e71f1f719" />
