### PR TITLE
Add 'US:US:Express' shield definition

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -686,6 +686,7 @@ export function loadShields() {
       "US:US:Business:Truck": ["BUS", "TRK"],
       "US:US:Alternate": ["ALT"],
       "US:US:Alternate:Truck:Business": ["ALT", "TRK", "BUS"],
+      "US:US:Express": ["EXPR"],
     },
   };
 


### PR DESCRIPTION
Just like Interstates, some U.S. Highways have a "local/express lane" system. I've added the appropriate banner for them.