### PR TITLE
Shields of Morocco

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -128,6 +128,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .dz,
 .gh,
 .mg,
+.ma,
 .ne,
 .za,
 .am,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -3456,6 +3456,28 @@ export function loadShields() {
     Color.shields.white
   );
 
+  // Morocco
+  shields["MA:A"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.white,
+    Color.shields.white
+  );
+  shields["MA:RN"] = roundedRectShield(
+    Color.shields.red,
+    Color.shields.black,
+    Color.shields.white
+  );
+  shields["MA:RR"] = roundedRectShield(
+    Color.shields.yellow,
+    Color.shields.black,
+    Color.shields.black
+  );
+  shields["MA:RP"] = roundedRectShield(
+    Color.shields.white,
+    Color.shields.black,
+    Color.shields.black
+  );
+
   // Niger
   shields["NE:N-roads"] = roundedRectShield(
     Color.shields.red,


### PR DESCRIPTION
Added shield definitions for Morocco’s auto-, national, regional, and provincial routes. Omitted forest roads for now until we know how they’ll be tagged.

[<img width="800" height="600" alt="Blue, red, and yellow, and white shields around Errahma and Oulad Azzouz." src="https://github.com/user-attachments/assets/2f4e717a-a5b5-4f60-a059-60fd754110df" />](https://preview.americanamap.org/pr/1386/#map=12/33.50778/-7.71523&language=fr)

Fixes #572.