### PR TITLE
Florida bannered shields

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1194,6 +1194,9 @@ export function loadShields() {
       top: 6,
       bottom: 4,
     },
+    bannerMap: {
+      "US:FL:Business": ["BUS"],
+    },
   };
   shields["US:FL:Toll"] = {
     spriteBlank: "shield_us_fl_toll",

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1223,6 +1223,7 @@ export function loadShields() {
   shields["US:FL:CR"] = {
     ...pentagonUpShield(3, 15, Color.shields.blue, Color.shields.yellow),
     bannerMap: {
+      "US:FL:CR:Alternate": ["ALT"],
       "US:FL:CR:Truck": ["TRK"],
     },
   };

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -1210,16 +1210,6 @@ export function loadShields() {
       spriteBlank: "shield_us_fl_turnpike",
     },
   };
-
-  shields["US:DE"] = {
-    ...ovalShield(Color.shields.white, Color.shields.black),
-    bannerMap: {
-      "US:DE:Alternate": ["ALT"],
-      "US:DE:Business": ["BUS"],
-      "US:DE:Truck": ["TRK"],
-    },
-  };
-
   shields["US:FL:CR"] = {
     ...pentagonUpShield(3, 15, Color.shields.blue, Color.shields.yellow),
     bannerMap: {


### PR DESCRIPTION
Added shield definitions for business state roads and alternate county roads in Florida.

[<img width="400" height="300" alt="Shields for State Road 44 and State Road 44 Business" src="https://github.com/user-attachments/assets/813bea95-6c63-4631-8cb0-7412bbd6f3ff" />](https://preview.americanamap.org/pr/1397/#map=14/29.01679/-80.94026)

[<img width="400" height="300" alt="Shields for County Road 579 and County Road 579 Alternate." src="https://github.com/user-attachments/assets/9f37d4a8-bc5a-4b90-b484-170a2e724966" />](https://preview.americanamap.org/pr/1397/#map=13/28.30287/-82.24402)

Fixes #1385, fixes #1388.