### PR TITLE
Enforce use of `import type`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7127,7 +7127,7 @@
       "version": "0.1.1",
       "license": "CC0-1.0",
       "dependencies": {
-        "@types/node": "^20.8.4",
+        "@types/node": "^22.19.19",
         "color-rgba": "^2.4.0",
         "maplibre-gl": "^2.4.0",
         "mocha": "^10.2.0"
@@ -7151,15 +7151,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
-      }
-    },
-    "shieldlib/node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "shieldlib/node_modules/earcut": {

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,10 +1,10 @@
 import Benchmark from "benchmark";
 import {
   expression,
-  LayerSpecification,
+  type LayerSpecification,
   StyleExpression,
   EvaluationContext,
-  Feature,
+  type Feature,
 } from "@maplibre/maplibre-gl-style-spec";
 
 import { build } from "../src/layer/index.js";

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,6 +1,6 @@
 import { stat, copyFile, mkdir } from "node:fs/promises";
 
-import esbuild, { BuildContext, BuildOptions } from "esbuild";
+import esbuild, { type BuildContext, type BuildOptions } from "esbuild";
 
 const maybeLocalConfig = async (name = "local.config.js") => {
   let exists = await stat(name)

--- a/scripts/extract_layer.ts
+++ b/scripts/extract_layer.ts
@@ -1,7 +1,7 @@
 import * as Style from "../src/js/style.js";
 import config from "../src/config.js";
-import { Command, Option, OptionValues } from "commander";
-import { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
+import { Command, Option, type OptionValues } from "commander";
+import type { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";
 
 const program = new Command();
 program

--- a/scripts/generate_samples.ts
+++ b/scripts/generate_samples.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import {
-  Browser,
-  BrowserContext,
+  type Browser,
+  type BrowserContext,
   chromium,
   firefox,
   webkit,

--- a/scripts/generate_shield_defs.ts
+++ b/scripts/generate_shield_defs.ts
@@ -1,6 +1,6 @@
 import * as ShieldDef from "../src/js/shield_defs.js";
 import * as fs from "node:fs";
-import { Command, OptionValues } from "commander";
+import { Command, type OptionValues } from "commander";
 
 const program = new Command();
 program.option("-o, --outfile <file>", "output file", "-");

--- a/scripts/generate_style.ts
+++ b/scripts/generate_style.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 
-import { Command, OptionValues } from "commander";
+import { Command, type OptionValues } from "commander";
 import { validateStyleMin as validate } from "@maplibre/maplibre-gl-style-spec";
 import type { StyleSpecification } from "maplibre-gl";
 

--- a/scripts/serve.ts
+++ b/scripts/serve.ts
@@ -1,4 +1,4 @@
-import { BuildContext } from "esbuild";
+import type { BuildContext } from "esbuild";
 import open from "open";
 
 import { buildContext } from "./build";

--- a/scripts/sprites.ts
+++ b/scripts/sprites.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { glob } from "glob";
-import { Sprites, SpriteSheetResult, SvgId } from "@basemaps/sprites";
+import { Sprites, type SpriteSheetResult, type SvgId } from "@basemaps/sprites";
 
 await fs.mkdir("./dist/sprites/", { recursive: true });
 

--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -1,4 +1,4 @@
-import { Command, Option, OptionValues } from "commander";
+import { Command, Option, type OptionValues } from "commander";
 import fs from "node:fs";
 import zlib from "node:zlib";
 import type { LayerSpecification } from "@maplibre/maplibre-gl-style-spec";

--- a/scripts/taginfo.ts
+++ b/scripts/taginfo.ts
@@ -21,7 +21,7 @@ import {
   shieldPredicate,
   networkPredicate,
 } from "../src/js/shield_format.js";
-import { ShieldSpecification } from "@americana/maplibre-shield-generator/src/types.js";
+import type { ShieldSpecification } from "@americana/maplibre-shield-generator/src/types.js";
 
 await mkdir("dist/shield-sample", { recursive: true });
 

--- a/shieldlib/package.json
+++ b/shieldlib/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/osm-americana/openstreetmap-americana#readme",
   "dependencies": {
-    "@types/node": "^20.8.4",
+    "@types/node": "^22.19.19",
     "color-rgba": "^2.4.0",
     "maplibre-gl": "^2.4.0",
     "mocha": "^10.2.0"

--- a/shieldlib/src/custom_shields.ts
+++ b/shieldlib/src/custom_shields.ts
@@ -1,8 +1,6 @@
-"use strict";
-
 import * as ShieldDraw from "./shield_canvas_draw";
 import { ShieldRenderingContext } from "./shield_renderer";
-import { ShapeBlankParams } from "./types";
+import type { ShapeBlankParams } from "./types";
 
 // Special case for Allegheny, PA Belt System
 export function paBelt(

--- a/shieldlib/src/document_graphics.ts
+++ b/shieldlib/src/document_graphics.ts
@@ -1,4 +1,4 @@
-import { Bounds, GraphicsFactory } from "./types";
+import type { Bounds, GraphicsFactory } from "./types";
 
 /**
  * Get the Maplibre pixel reation being used in this browser. This determines

--- a/shieldlib/src/headless_graphics.ts
+++ b/shieldlib/src/headless_graphics.ts
@@ -1,4 +1,4 @@
-import { Bounds, GraphicsFactory } from "./types";
+import type { Bounds, GraphicsFactory } from "./types";
 import { createCanvas } from "canvas";
 
 export class HeadlessGraphicsFactory implements GraphicsFactory {

--- a/shieldlib/src/screen_gfx.ts
+++ b/shieldlib/src/screen_gfx.ts
@@ -1,4 +1,4 @@
-import { StyleImage } from "maplibre-gl";
+import type { StyleImage } from "maplibre-gl";
 
 import rgba from "color-rgba";
 

--- a/shieldlib/src/shield.ts
+++ b/shieldlib/src/shield.ts
@@ -1,18 +1,16 @@
-"use strict";
-
 import * as ShieldText from "./shield_text";
 import * as ShieldDraw from "./shield_canvas_draw";
 import * as Gfx from "./screen_gfx";
 import { drawBanners, drawBannerHalos, getBannerCount } from "./shield_banner";
 import { ShieldRenderingContext } from "./shield_renderer";
-import {
+import type {
   Dimension,
   RouteDefinition,
   ShieldDefinition,
   ShieldDefinitions,
 } from "./types";
-import { TextPlacement } from "./shield_text";
-import { StyleImage } from "maplibre-gl";
+import type { TextPlacement } from "./shield_text";
+import type { StyleImage } from "maplibre-gl";
 
 const narrowCharacters = /[1IJijl .-]/g;
 const maxRefLength = 7;

--- a/shieldlib/src/shield_banner.ts
+++ b/shieldlib/src/shield_banner.ts
@@ -1,7 +1,7 @@
 import { shieldFont } from "./screen_gfx";
 import { ShieldRenderingContext } from "./shield_renderer";
-import { TextPlacement, layoutShieldText } from "./shield_text";
-import { Dimension, ShieldDefinition, TextLayout } from "./types";
+import { type TextPlacement, layoutShieldText } from "./shield_text";
+import type { Dimension, ShieldDefinition, TextLayout } from "./types";
 
 let bannerLayout: TextLayout = {
   constraintFunc: "rect",

--- a/shieldlib/src/shield_canvas_draw.ts
+++ b/shieldlib/src/shield_canvas_draw.ts
@@ -1,13 +1,14 @@
-"use strict";
-
 /**
  * Shield blanks which are drawn rather built from raster shield blanks
  */
 
 import * as ShieldText from "./shield_text";
 import { loadCustomShields } from "./custom_shields";
-import { ShapeDrawFunction, ShieldRenderingContext } from "./shield_renderer";
-import { ShapeBlankParams } from "./types";
+import {
+  type ShapeDrawFunction,
+  ShieldRenderingContext,
+} from "./shield_renderer";
+import type { ShapeBlankParams } from "./types";
 
 const minGenericShieldWidth = 20;
 const maxGenericShieldWidth = 34;

--- a/shieldlib/src/shield_helper.ts
+++ b/shieldlib/src/shield_helper.ts
@@ -1,4 +1,4 @@
-import { ShieldDefinition, TextLayout } from "./types";
+import type { ShieldDefinition, TextLayout } from "./types";
 
 /**
  * Constrain the text to a rounded rectangle

--- a/shieldlib/src/shield_renderer.ts
+++ b/shieldlib/src/shield_renderer.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   Map as MapLibre,
-  type MapStyleImageMissingEvent,
-  type StyleImage,
-  type StyleImageMetadata,
+  MapStyleImageMissingEvent,
+  StyleImage,
+  StyleImageMetadata,
 } from "maplibre-gl";
 import type {
   Bounds,

--- a/shieldlib/src/shield_renderer.ts
+++ b/shieldlib/src/shield_renderer.ts
@@ -1,10 +1,10 @@
 import {
   Map as MapLibre,
-  MapStyleImageMissingEvent,
-  StyleImage,
-  StyleImageMetadata,
+  type MapStyleImageMissingEvent,
+  type StyleImage,
+  type StyleImageMetadata,
 } from "maplibre-gl";
-import {
+import type {
   Bounds,
   DebugOptions,
   GraphicsFactory,

--- a/shieldlib/src/shield_text.ts
+++ b/shieldlib/src/shield_text.ts
@@ -1,8 +1,6 @@
-"use strict";
-
 import * as Gfx from "./screen_gfx.js";
 import { ShieldRenderingContext } from "./shield_renderer.js";
-import {
+import type {
   BoxPadding,
   Dimension,
   ShieldDefinition,

--- a/shieldlib/src/types.ts
+++ b/shieldlib/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   StyleImage,
   StyleImageInterface,
   StyleImageMetadata,

--- a/shieldlib/tsconfig.json
+++ b/shieldlib/tsconfig.json
@@ -4,7 +4,9 @@
     "module": "ES2020",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   },
   "exclude": ["node_modules", "**/*.json"],
   "include": ["src/**/*.ts", "scripts/**.ts", "src/shield.js", "src/shield.js"]

--- a/src/debug_config.ts
+++ b/src/debug_config.ts
@@ -1,4 +1,4 @@
-import { DebugOptions } from "@americana/maplibre-shield-generator/src/types.js";
+import type { DebugOptions } from "@americana/maplibre-shield-generator/src/types.js";
 import config from "./config.js";
 
 export const debugOptions: DebugOptions = {};

--- a/src/js/map_builder.ts
+++ b/src/js/map_builder.ts
@@ -14,11 +14,13 @@ import {
 } from "../js/shield_format.js";
 
 import * as Poi from "../js/poi.js";
-import { getLocales } from "@americana/diplomat";
 import * as Style from "./style.js";
-import maplibregl, { MapOptions, StyleSpecification } from "maplibre-gl";
+import maplibregl, {
+  type MapOptions,
+  type StyleSpecification,
+} from "maplibre-gl";
 import { MapView } from "./map_view.js";
-import { DebugOptions } from "@americana/maplibre-shield-generator/src/types.js";
+import type { DebugOptions } from "@americana/maplibre-shield-generator/src/types.js";
 import { getGlobalStateForLocalization, getLocales } from "@americana/diplomat";
 
 export function buildStyle(): StyleSpecification {

--- a/src/js/poi.ts
+++ b/src/js/poi.ts
@@ -2,7 +2,11 @@ import {
   transposeImageData,
   AbstractShieldRenderer,
 } from "@americana/maplibre-shield-generator";
-import { Map, MapStyleImageMissingEvent, StyleImage } from "maplibre-gl";
+import {
+  Map,
+  type MapStyleImageMissingEvent,
+  type StyleImage,
+} from "maplibre-gl";
 
 export function missingIconHandler(
   shieldRenderer: AbstractShieldRenderer,

--- a/src/js/style.ts
+++ b/src/js/style.ts
@@ -1,4 +1,4 @@
-import { StyleSpecification } from "@maplibre/maplibre-gl-style-spec";
+import type { StyleSpecification } from "@maplibre/maplibre-gl-style-spec";
 import { getGlobalStateForLocalization } from "@americana/diplomat";
 import * as Layers from "../layer/index.js";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,9 @@
     "module": "ESNext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   },
   "include": ["src/**/*.ts", "shieldlib/src/headless_graphics.ts"]
 }


### PR DESCRIPTION
If the TypeScript compiler decides that an import statement only imports
types, no values, then the entire import statement will be erased at
runtime. A non-typechecking runner such as esbuild or node cannot
statically do this, preserving the import statement and resulting in
possibly subtle differences.

Instead, these import statements should be written as import type
statements to make the distinction statically knowable. These options
make it an error if a type is imported without this keyword.

It's possible that a class (which is both a value and a type) could be
imported and only used as a type, and indeed it might be a good change
to make it a type import instead, but this change does not attempt that.