### PR TITLE
Render hamlet place labels

### DIFF
--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -166,6 +166,14 @@
     },
     {
       "key": "place",
+      "value": "hamlet",
+      "object_types": ["node"],
+      "description": "Hamlets are marked with a dot.",
+      "doc_url": "https://openmaptiles.org/schema/#place",
+      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/place_dot.svg"
+    },
+    {
+      "key": "place",
       "value": "suburb",
       "object_types": ["node"],
       "description": "Suburbs are labeled in capital letters.",

--- a/src/layer/index.js
+++ b/src/layer/index.js
@@ -245,6 +245,7 @@ export function build(locales) {
     lyrPlace.neighborhood,
     lyrPlace.quarter,
     lyrPlace.suburb,
+    lyrPlace.hamlet,
     lyrPlace.village,
     lyrPlace.town,
     lyrPlace.city,

--- a/src/layer/place.js
+++ b/src/layer/place.js
@@ -104,6 +104,53 @@ export const village = {
   "source-layer": "place",
 };
 
+export const hamlet = {
+  id: "place_hamlet",
+  type: "symbol",
+  paint: cityLabelPaint,
+  filter: ["all", filterPlace("hamlet"), minorLocationStepFilter],
+  layout: {
+    "text-font": ["Americana-Bold"],
+    "text-size": {
+      base: 1.0,
+      stops: [
+        [12, 8],
+        [14, 9],
+        [16, 11],
+      ],
+    },
+    "icon-image": iconImage,
+    "icon-size": {
+      base: 1.0,
+      stops: [
+        [12, 0.15],
+        [14, 0.25],
+        [16, 0.35],
+      ],
+    },
+    "text-field": localizedNameWithLocalGloss,
+    "text-anchor": "bottom",
+    "text-variable-anchor": [
+      "bottom",
+      "bottom-right",
+      "bottom-left",
+      "right",
+      "left",
+    ],
+    "text-justify": "auto",
+    "text-radial-offset": 0.5,
+    "icon-optional": false,
+    "text-max-width": 8,
+    "icon-padding": 0,
+    "text-padding": 1,
+    "icon-allow-overlap": false,
+  },
+  source: "openmaptiles",
+  minzoom: 13,
+  maxzoom: 17,
+  "source-layer": "place",
+};
+
 export const town = {
   id: "place_town",
   type: "symbol",
@@ -613,6 +660,10 @@ export const legendEntries = [
     description: "Small village",
     layers: [village.id],
     filter: nonCapitalFilter,
+  },
+  {
+    description: "Hamlet",
+    layers: [hamlet.id],
   },
   {
     description: "Major district",

--- a/test/sample_locations.json
+++ b/test/sample_locations.json
@@ -97,6 +97,14 @@
     }
   },
   {
+    "location": "16.2/39.150521/-123.542979",
+    "name": "navarro_hamlet",
+    "viewport": {
+      "width": 400,
+      "height": 400
+    }
+  },
+  {
     "location": "12/38.86185/-77.20877",
     "name": "northen_va_highways",
     "viewport": {


### PR DESCRIPTION
## Summary

This adds rendering for `place=hamlet` labels so small populated places can appear at higher zooms. I kept it close to the existing village treatment, with smaller text/icon sizing, then added the related legend, taginfo, and sample-location entries for discoverability and PR preview coverage.

Fixes #1401.

## Verification

- `npm run style`
- `npm run taginfo`
- `npm run build`
- Local visual check at `16.2/39.150521/-123.542979`: the public map did not show Navarro, while this branch shows the Navarro label and place dot.

I also ran `npm run build:shieldlib; npm test`. The shieldlib build completed; the test run reported 16 passing and 3 failures from a Windows path issue where paths are built as `C:\C:\projects\...`, which looks unrelated to this style-layer change.

This was implemented with Codex assistance, with the final patch manually reviewed and kept focused.