### PR TITLE
fix raw language code unable to be entered

### DIFF
--- a/src/js/language_control.js
+++ b/src/js/language_control.js
@@ -210,6 +210,7 @@ export class LanguageControl {
       const tokenField = (this._tokenField = new Tokenfield({
         el: inputField,
         items: getLanguageNamesByCode(),
+        addItemOnBlur: true,
         validateNewItem: (value) => {
           // Write-ins must be well-formed IETF language tags.
           try {


### PR DESCRIPTION
regarding this popup:

<img width="446" height="282" alt="Image" src="https://github.com/user-attachments/assets/0403d415-52b4-42f2-9b10-6a33c51d5a91" />

typing or pasting a raw code and then pressing _"Done"_ doesn't work. you have to press <kbd>Enter ⏎</kbd> first, then click _"Done"_. 

This is a bit unintuitive, and made me think that raw values weren't supported. 


I've tested that validation still works: typing `123` won't be accepted, but something like `en-US` will be.