### PR TITLE
Render campground icon

### DIFF
--- a/icons/poi_tent.svg
+++ b/icons/poi_tent.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+ <path d="M 15,13 10,3 5,13 H 3 v 2 h 14 v -2 z m -8,0 3,-6 3,6 z"/>
+</svg>

--- a/icons/poi_tent.svg
+++ b/icons/poi_tent.svg
@@ -1,3 +1,0 @@
-<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
- <path d="M 15,13 10,3 5,13 H 3 v 2 h 14 v -2 z m -8,0 3,-6 3,6 z"/>
-</svg>

--- a/icons/poi_tent_circle.svg
+++ b/icons/poi_tent_circle.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="10" cy="10" r="9.5" fill="#fff" stroke="#000"/>
+ <path d="M 15,13 10,3 5,13 H 3 v 2 h 14 v -2 z m -8,0 3,-6 3,6 z"/>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1323,7 +1323,6 @@
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -714,6 +714,14 @@
       "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/poi_museum.svg"
     },
     {
+      "key": "tourism",
+      "value": "camp_site",
+      "object_types": ["node", "area"],
+      "description": "Campgrounds are marked by a circled icon representing a tent.",
+      "doc_url": "https://openmaptiles.org/schema/#poi",
+      "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/poi_tent_circle.svg"
+    },
+    {
       "key": "amenity",
       "value": "clinic",
       "object_types": ["node", "area"],

--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -309,6 +309,14 @@ var iconDefs = {
     color: Color.poi.infrastructure,
     description: "College or university",
   },
+  campsite: {
+    classes: {
+      campsite: ["camp_site"],
+    },
+    sprite: "poi_tent_circle",
+    color: Color.poi.outdoor,
+    description: "Campground",
+  },
   townhall: {
     classes: {
       town_hall: ["townhall"],
@@ -413,7 +421,10 @@ export const poi = {
         ...getSubclasses(iconDefs.pow_uu),
       ],
       Color.poi.infrastructure,
-      [...getSubclasses(iconDefs.cemetery)],
+      [
+        ...getSubclasses(iconDefs.cemetery),
+        ...getSubclasses(iconDefs.campsite),
+      ],
       Color.poi.outdoor,
       Color.poi.infrastructure,
     ],
@@ -428,7 +439,11 @@ export const poi = {
       10,
       ["station", "halt"],
       12,
-      ["bus_station", "subway"],
+      [
+        "bus_station", 
+        "subway",
+        ...getSubclasses(iconDefs.campsite),
+      ],
       14,
       [
         "bus_stop",

--- a/src/layer/poi.js
+++ b/src/layer/poi.js
@@ -439,11 +439,7 @@ export const poi = {
       10,
       ["station", "halt"],
       12,
-      [
-        "bus_station", 
-        "subway",
-        ...getSubclasses(iconDefs.campsite),
-      ],
+      ["bus_station", "subway", ...getSubclasses(iconDefs.campsite)],
       14,
       [
         "bus_stop",

--- a/test/sample_locations.json
+++ b/test/sample_locations.json
@@ -102,8 +102,8 @@
     "viewport": {
       "width": 400,
       "height": 400
-    },
-  }
+    }
+  },
   {
     "location": "14.01/37.74236/-119.57984",
     "name": "yosemite_valley_camping",

--- a/test/sample_locations.json
+++ b/test/sample_locations.json
@@ -102,6 +102,13 @@
     "viewport": {
       "width": 400,
       "height": 400
+    },
+    {
+    "location": "14.01/37.74236/-119.57984",
+    "name": "yosemite_valley_camping",
+    "viewport": {
+      "width": 400,
+      "height": 400
     }
   }
 ]

--- a/test/sample_locations.json
+++ b/test/sample_locations.json
@@ -103,7 +103,8 @@
       "width": 400,
       "height": 400
     },
-    {
+  }
+  {
     "location": "14.01/37.74236/-119.57984",
     "name": "yosemite_valley_camping",
     "viewport": {


### PR DESCRIPTION
Fixes #1126. Adds campgrounds (OSM `tourism=camp_site`, OMT `class=campsite` + `subclass=camp_site`). As I proposed in #1126, I've rendered campgrounds using a tent inscribed in a circle: 
<img width="20" height="20" alt="poi_tent_circle" src="https://github.com/user-attachments/assets/b89b954d-4298-4114-808a-15e10f8a878c" />

Campgrounds appear in the tiles at z14 and that's where this PR renders them. That's quite early compared to most other POIs (and compared to e.g. Carto, which renders icons at raster z16/vector z15), but campgrounds are usually in very sparse areas. American road maps often show them on state-scale maps.
37.74209/-119.58082
<img width="1502" height="722" alt="Screenshot 2026-06-10 at 11 10 40 PM" src="https://github.com/user-attachments/assets/e6367ca2-85ec-47d6-b96f-ebfcd2f4c797" />

 I propose rendering them using our outdoors green color. Right now the only other POI icon using that is cemeteries. Campgrounds frequently appear in parks, so contrast with their background and labels is key. I think the drop shadow and the lack of bold font does the job sufficiently.
38.92803/-78.3283
<img width="787" height="518" alt="Screenshot 2026-06-10 at 11 16 19 PM" src="https://github.com/user-attachments/assets/04eca64c-0d0d-4455-92a6-92469dc80d64" />

The counterpart to the circle campground icon would be rendering the individual camp pitches/sites (`tourism=camp_pitch`) with just a tent icon, continuing our bus stop/station and restaurant/food court system. Unfortunately these are not present in the OMT tiles. I include the solo tent icon in the PR anyways: 
<img width="20" height="20" alt="poi_tent" src="https://github.com/user-attachments/assets/b438d5da-9fa3-45fc-8682-2fa9e05c35e6" />
(EDIT: removed the pitch icon)

Campsites are also often mapped as areas, but are only present as points in the tiles, precluding area rendering for now.