### PR TITLE
Cyprus B/E/F road shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -157,6 +157,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .bg,
 .by,
 .ch,
+.cy,
 .cz,
 .ee,
 .es,

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -4101,6 +4101,16 @@ export function loadShields() {
     Color.shields.white
   );
 
+  // Cyprus
+  shields["CY:B"] =
+    shields["CY:E"] =
+    shields["CY:F"] =
+      roundedRectShield(
+        Color.shields.blue,
+        Color.shields.yellow,
+        Color.shields.yellow
+      );
+
   // Czechia
   shields["CZ:national"] = roundedRectShield(
     Color.shields.red,


### PR DESCRIPTION
Added shields for Cyprus B, E, and F roads based on the networks `CY:B`, `CY:E`, and `CY:F`, respectively. This takes care of all the non-motorway shields in Cyprus as well as Akrotiri and Dhekelia, a British Overseas Territory. The E and F roads are hardly mapped at all, but it stands to reason that they’d follow the same pattern as the B roads.

[<img width="400" height="300" alt="B3" src="https://github.com/user-attachments/assets/4fbc689e-c1a5-49bd-a98f-85a7824ec85f" />](https://preview.americanamap.org/pr/1422/#map=13/34.99028/33.74445) [<img width="400" height="300" alt="E327" src="https://github.com/user-attachments/assets/098d0809-2569-4d1d-a440-8200595c00a3" />](https://preview.americanamap.org/pr/1422/#map=12/35.01121/33.98517)

Fixes #1421.