### PR TITLE
Add park tags to taginfo file

### DIFF
--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -978,6 +978,34 @@
       "icon_url": "https://raw.githubusercontent.com/osm-americana/openstreetmap-americana/main/icons/poi_gravestone.svg"
     },
     {
+      "key": "boundary",
+      "value": "protected_area",
+      "object_types": ["node", "area"],
+      "description": "Park areas shaded with a green fill and labeled in green text.",
+      "doc_url": "https://openmaptiles.org/schema/#park"
+    },
+    {
+      "key": "boundary",
+      "value": "national_park",
+      "object_types": ["node", "area"],
+      "description": "Park areas shaded with a green fill and labeled in green text.",
+      "doc_url": "https://openmaptiles.org/schema/#park"
+    },
+    {
+      "key": "leisure",
+      "value": "nature_reserve",
+      "object_types": ["node", "area"],
+      "description": "Park areas shaded with a green fill and labeled in green text.",
+      "doc_url": "https://openmaptiles.org/schema/#park"
+    },
+    {
+      "key": "leisure",
+      "value": "park",
+      "object_types": ["node", "area"],
+      "description": "Park areas shaded with a green fill and labeled in green text.",
+      "doc_url": "https://openmaptiles.org/schema/#landcover"
+    },
+    {
       "key": "leisure",
       "value": "pitch",
       "object_types": ["area"],

--- a/scripts/taginfo_template.json
+++ b/scripts/taginfo_template.json
@@ -980,21 +980,21 @@
     {
       "key": "boundary",
       "value": "protected_area",
-      "object_types": ["node", "area"],
+      "object_types": ["area"],
       "description": "Park areas shaded with a green fill and labeled in green text.",
       "doc_url": "https://openmaptiles.org/schema/#park"
     },
     {
       "key": "boundary",
       "value": "national_park",
-      "object_types": ["node", "area"],
+      "object_types": ["area"],
       "description": "Park areas shaded with a green fill and labeled in green text.",
       "doc_url": "https://openmaptiles.org/schema/#park"
     },
     {
       "key": "leisure",
       "value": "nature_reserve",
-      "object_types": ["node", "area"],
+      "object_types": ["area"],
       "description": "Park areas shaded with a green fill and labeled in green text.",
       "doc_url": "https://openmaptiles.org/schema/#park"
     },


### PR DESCRIPTION
When making #1435, I noticed that the tags that the style interprets as parks didn't make it into the taginfo file. This PR fixes that, adding `leisure=nature_reserve`, `boundary=national_park`, `boundary=protected_area`, and `leisure=park` to the list of tags the style uses. The first three were rendered in #49, and the last in #306.