### PR TITLE
Add Akrotiri and Dhekelia to shield coverage map

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -190,6 +190,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .gb,
 .au,
 .nz,
+.akrotiridhekelia,
 .bl,
 .mf,
 .nc,

--- a/scripts/status_map.ts
+++ b/scripts/status_map.ts
@@ -7,6 +7,10 @@ function fillPaths(svg: string, codes: string[]): string {
   const selectors: Set<string> = new Set(
     codes.map((code) => `.${code.toLowerCase()}`)
   );
+  if (selectors.has(".cy")) {
+    // Akrotiri and Dhekelia uses Cypriot road signage.
+    selectors.add(".akrotiridhekelia");
+  }
   if (selectors.has(".fr")) {
     // French overseas territories use the FR prefix.
     selectors.add(".bl");


### PR DESCRIPTION
#558 and #1422 added Cypriot shields. Despite its status as a British Overseas Territory, Akrotiri and Dhekelia uses Cypriot road signs and numbering, so we can color that bubble in too.