### PR TITLE
Add Northern Cyprus main road shields

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -191,6 +191,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .au,
 .nz,
 .akrotiridhekelia,
+.northerncyprus,
 .bl,
 .mf,
 .nc,

--- a/scripts/status_map.ts
+++ b/scripts/status_map.ts
@@ -10,6 +10,8 @@ function fillPaths(svg: string, codes: string[]): string {
   if (selectors.has(".cy")) {
     // Akrotiri and Dhekelia uses Cypriot road signage.
     selectors.add(".akrotiridhekelia");
+    // Northern Cyprus routes use CY prefix with Cyprus.
+    selectors.add(".northerncyprus");
   }
   if (selectors.has(".fr")) {
     // French overseas territories use the FR prefix.

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -4118,6 +4118,13 @@ export function loadShields() {
         Color.shields.yellow
       );
 
+  // Northern Cyprus
+  shields["CY:national"] = roundedRectShield(
+    Color.shields.blue,
+    Color.shields.white,
+    Color.shields.white
+  );
+
   // Czechia
   shields["CZ:national"] = roundedRectShield(
     Color.shields.red,


### PR DESCRIPTION
Added a shield for main roads in Northern Cyprus.

[<img width="800" height="600" alt="D.30 in Northern Cyprus, A9 in Cyprus." src="https://github.com/user-attachments/assets/9b960928-c466-4407-a579-a05b21cb0327" />](https://preview.americanamap.org/pr/1446/#map=11/35.1315/32.9305)

Fixes #1443.