### PR TITLE
Update Quintana Roo tag

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -578,7 +578,7 @@ export function loadShields() {
     "OAX",
     "PUE",
     "QRO",
-    "Q.ROO",
+    "QROO",
     "SLP",
     "SIN",
     "SON",


### PR DESCRIPTION
Quintana Roo state highways are now being tagged consistently as [`network=MX:QROO`](https://taginfo.openstreetmap.org/tags/network=MX%3AQROO), as [documented on the wiki](https://wiki.openstreetmap.org/wiki/Special:PermanentLink/2894097#Relaciones_para_caminos).