### PR TITLE
feat: add Panama national route shields

### DIFF
--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -543,9 +543,6 @@ export function loadShields() {
     Color.shields.white
   );
 
-  // Panama
-  shields["PA:national"] = badgeShieldCrossbar;
-
   // Mexico
 
   // Carreteras Federales
@@ -635,6 +632,9 @@ export function loadShields() {
       bottom: 8,
     },
   };
+
+  // Panama
+  shields["PA:national"] = badgeShieldCrossbar;
 
   // United States
 

--- a/src/js/shield_defs.js
+++ b/src/js/shield_defs.js
@@ -543,6 +543,9 @@ export function loadShields() {
     Color.shields.white
   );
 
+  // Panama
+  shields["PA:national"] = badgeShieldCrossbar;
+
   // Mexico
 
   // Carreteras Federales

--- a/src/shieldtest.js
+++ b/src/shieldtest.js
@@ -73,6 +73,7 @@ let networks = [
   "US:MN:Hennepin:Park_Access",
   "US:PA",
   "US:PA:Turnpike",
+  "PA:national",
 
   "CA:AB:primary",
   "CA:SK:tertiary",


### PR DESCRIPTION
## Summary

- render `PA:national` routes with the crossbar badge used for Panama’s national route markers
- add the network to the shield test gallery for visual coverage

## Validation

- `npm test`
- `npm run build`
- `npx prettier --check src/js/shield_defs.js src/shieldtest.js`
- verified the generated `PA:national` definition uses the crossbar badge sprites

Fixes #1455
