### PR TITLE
Add Panama to shield coverage map

### DIFF
--- a/doc-img/shield_map_world.svg
+++ b/doc-img/shield_map_world.svg
@@ -117,6 +117,7 @@ See the end of this file for a list of available jurisdictions and their codes. 
 .ca,
 .ht,
 .mx,
+.pa,
 .us,
 .ar,
 .cl,


### PR DESCRIPTION
This is a followup to #1458 that adds Panama to the shield coverage world map by running `npm run status_map`.