### PR TITLE
Add a rank filter for parks at low z

### DIFF
--- a/src/layer/park.js
+++ b/src/layer/park.js
@@ -3,11 +3,16 @@
 import { localizedName } from "@americana/diplomat";
 import * as Color from "../constants/color.js";
 
-const parkLayerFilter = ["!=", ["get", "class"], "aboriginal_lands"];
+const parkStepFilter = [
+  "step",
+  ["zoom"],
+  ["<=", ["get", "rank"], 2], //Only rank 2 (dynamic) to z10
+  10,
+  [">=", ["get", "rank"], 1], //Show all past z10
+];
 
 export const fill = {
   id: "protected-area_fill",
-  filter: parkLayerFilter,
   type: "fill",
   paint: {
     "fill-color": Color.parkFill,
@@ -18,7 +23,6 @@ export const fill = {
 
 export const outline = {
   id: "protected-area_outline",
-  filter: parkLayerFilter,
   type: "line",
   paint: {
     "line-color": Color.parkOutline,
@@ -31,7 +35,7 @@ export const outline = {
 export const label = {
   id: "protected-area_label",
   type: "symbol",
-  filter: ["all", ["has", "rank"], parkLayerFilter],
+  filter: parkStepFilter,
   paint: {
     "text-color": Color.parkLabel,
     "text-halo-blur": 1,


### PR DESCRIPTION
Fixes #1290. Implements a `rank` filter on parks similar to what was implemented in [peak.js](https://github.com/osm-americana/openstreetmap-americana/blob/main/src/layer/peak.js). In practice, this removes (EDIT: the labels of) a bunch of relatively insignificant wilderness areas, state/regional parks, and protected forests from very low zooms, reducing clutter on the map while preserving a fairly park-forward rendering.

I picked `rank<=2` for z5 through 9 subjectively after testing various options. It seemed to e.g. surface most big national parks at z5, although the exact way OpenMapTiles chooses `rank` is still a black box to me. A `rank=1` filter eliminates some national forests and such, although not all, plus some national parks from z5, so I went with the more inclusive one. After z10 everything appears like it did before, but most big park areas of any type render before that once they take up enough of a tile.

Also removes the `aboriginal_lands` filter added in #1019, I think this has been vestigial since https://github.com/openmaptiles/openmaptiles/pull/1604 when OpenMapTiles separated out indigenous areas from the parks layer.

Samples:
Western US z5
Current:
<img width="1097" height="740" alt="Screenshot 2026-08-09 at 10 35 57 PM" src="https://github.com/user-attachments/assets/f952c401-66aa-49ff-b33f-7ef907f1648d" />

New:
<img width="1097" height="740" alt="Screenshot 2026-08-09 at 10 37 13 PM" src="https://github.com/user-attachments/assets/7ea7710f-4f8d-4e05-be4f-703b6735f447" />

Upper Midwest z5.5, referenced in https://github.com/aaroads-wiki/openstreetmap-americana/issues/7
Current:
<img width="1117" height="733" alt="Screenshot 2026-08-09 at 10 43 31 PM" src="https://github.com/user-attachments/assets/3e88c75e-1cbc-45e5-9d65-f77601cea62d" />

New:
<img width="1117" height="733" alt="Screenshot 2026-08-09 at 10 43 42 PM" src="https://github.com/user-attachments/assets/eec28617-1641-4926-aae8-4ef3dbc0d31f" />

Colorado z7:
Current:
<img width="949" height="704" alt="Screenshot 2026-08-09 at 10 52 20 PM" src="https://github.com/user-attachments/assets/1ea9e9b9-c894-4252-9308-0bf4107b073c" />

New:
<img width="949" height="704" alt="Screenshot 2026-08-09 at 10 52 27 PM" src="https://github.com/user-attachments/assets/394e5678-ce31-4d2d-ab8e-878effaa935d" />

France z5
Current:
<img width="830" height="747" alt="Screenshot 2026-08-09 at 11 08 30 PM" src="https://github.com/user-attachments/assets/5ced00ea-9406-4f4f-9fdb-122cb24fda13" />

New:
<img width="830" height="747" alt="Screenshot 2026-08-09 at 11 08 45 PM" src="https://github.com/user-attachments/assets/f16cfeee-a773-4d11-8679-33a0e8b9a255" />
